### PR TITLE
Fix README - npm install fails (name mismatch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Live demo http://transferwise.github.io/styleguide-components/
 It is recommended to use bower to import the latest version
 ```
 dependencies: {
-    "styleguide-components": "https://github.com/transferwise/styleguide-components.git#v1.2.0",
+    "tw-styleguide-components": "https://github.com/transferwise/styleguide-components/archive/1.4.0.tar.gz"
 }
 ```
 


### PR DESCRIPTION
``` bash
npm ERR! Invalid Package: expected styleguide-components but found tw-styleguide-components
```
