### PR TITLE
Remove spacing between <i> and transcluded elements

### DIFF
--- a/angular/components/tw-upload-droppable/tw-upload-droppable.directive.js
+++ b/angular/components/tw-upload-droppable/tw-upload-droppable.directive.js
@@ -25,7 +25,7 @@
 			template:
 			'<div class="text-center tw-upload-droppable-box" ng-class="{\'active\': $ctrl.isActive}"> \
 				<i class="icon icon-upload tw-upload-droppable-icon"></i>\
-				<h4 class="m-t-2">{{$ctrl.title}}</h4>\
+				<h4 class="m-t-2" ng-if="$ctrl.title">{{$ctrl.title}}</h4>\
 				<div class="row">\
 					<div class="col-xs-12 col-sm-6 col-sm-offset-3 m-t-1">\
 					<ng-transclude></ng-transclude>\


### PR DESCRIPTION
If there is no title set on the droppable and the consumer wants to convey info using the transclusion then the m-t-2 spacing makes the content look odd.