### PR TITLE
Add show-decimals option to tw-amount-currency-select

### DIFF
--- a/angular/components/tw-amount-currency-select/tw-amount-currency-select.directive.js
+++ b/angular/components/tw-amount-currency-select/tw-amount-currency-select.directive.js
@@ -23,6 +23,7 @@
 
 				amountReadOnly: '=',
 				onAmountChange: '&',
+				showDecimals: '=',
 
 				currency: '=',
 				currencies: '=',
@@ -54,6 +55,7 @@
 				class="form-control"  \
 				placeholder="{{ $ctrl.placeholder }}" \
 				tw-focusable  \
+				show-decimals="$ctrl.showDecimals" \
 				tw-number-input-formatter  \
 				ng-change="$ctrl.changedAmount()"  \
 				ng-model="$ctrl.ngModel" \

--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
 				<div data-spy="affix" data-offset-top="0">
 					<h5>Jump to:</h5>
 					<ul class="list-unstyled">
-						<li><a href="#amount-currency-select">Tw Amount Currency Select</a></li>
 						<li><a href="#focusable">Tw Focusable</a></li>
 						<li><a href="#validation">Tw Validation</a></li>
 						<li><a href="#select">Tw Select</a></li>
@@ -46,6 +45,7 @@
 						<li><a href="#radio">Tw Radio</a></li>
 						<li><a href="#date">Tw Date</a></li>
 						<li><a href="#currency-input">Tw Currency Input</a></li>
+						<li><a href="#amount-currency-select">Tw Amount Currency Select</a></li>
 						<li><a href="#dynamic">Tw Dynamic Control</a></li>
 						<li><a href="#requirements-form">Tw Requirements Form</a></li>
 					</ul>

--- a/partials/tw-amount-currency-select.html
+++ b/partials/tw-amount-currency-select.html
@@ -14,6 +14,7 @@
                 ng-max="vm.amountCurrencySelect.max"
                 placeholder="{{ vm.amountCurrencySelect.placeholder }}"
 
+                show-decimals="{{ vm.amountCurrencySelect.showDecimals }}"
                 on-amount-change="vm.log('amount input value changed:' + vm.model.components.amountCurrencySelect)"
 
                 currency="vm.model.components.currencySelected"
@@ -43,6 +44,7 @@
                 ng-max="vm.amountCurrencySelect.max"
                 placeholder="{{ vm.amountCurrencySelect.placeholder }}"
 
+                show-decimals="{{ vm.amountCurrencySelect.showDecimals }}"
                 on-amount-change="vm.log('amount input value changed:' + vm.model.components.amountCurrencySelect)"
 
                 currency="vm.model.components.currencySelected"
@@ -62,13 +64,14 @@
             </div>
         </div>
         <h5>Configuration</h5>
-<pre>&lt;tw-amount-curency-select tw-validation
+<pre>&lt;tw-amount-currency-select tw-validation
     ng-model="{{ vm.model.components.amountCurrencySelect }}"
     ng-required="{{ vm.amountCurrencySelect.required }}"
     ng-disabled="{{ vm.amountCurrencySelect.disabled }}"
     ng-min="{{ vm.amountCurrencySelect.min }}"
     ng-max="{{ vm.amountCurrencySelect.max }}"
     placeholder="{{ vm.amountCurrencySelect.placeholder }}"
+    show-decimals="{{ vm.amountCurrencySelect.showDecimals }}"
     on-amount-change="vm.log('amount input value changed:' + vm.model.components.amountCurrencySelect)"
     currency="{{ vm.model.components.currencySelected }}"
     currencies="{{ vm.select.options.currencySelect }}"
@@ -146,6 +149,14 @@
                 <tw-select
                     ng-model="vm.amountCurrencySelect.size"
                     options="vm.sizes" />
+            </div>
+            <div class="form-group">
+                <div class="checkbox">
+                    <label>
+                        <tw-checkbox ng-model="vm.amountCurrencySelect.showDecimals" />
+                        Show decimals?
+                    </label>
+                </div>
             </div>
             <div class="form-group">
                 <label class="control-label">


### PR DESCRIPTION
I couldn't really find a way to test it from here as `tw-number-input-formatter` is not present it doesn't format anyway.
But it follows the same logic used in tw-currency-input so I expect it to be ok.
If you have any idea to test, let me know :) (like is it possible to import it in another project without having it released?)