### PR TITLE
Tw upload changes

### DIFF
--- a/dist/js/styleguide-components.js
+++ b/dist/js/styleguide-components.js
@@ -5092,7 +5092,6 @@ var UploadController = function () {
 
     _classCallCheck(this, UploadController);
 
-    this.ngDisabled = false;
     this.$timeout = $timeout;
     this.$element = $element;
     this.$http = $http;

--- a/dist/js/styleguide-components.js
+++ b/dist/js/styleguide-components.js
@@ -5036,6 +5036,7 @@ var Upload = {
   template: _upload2.default,
   transclude: true,
   bindings: {
+    ngDisabled: '<',
     ngModel: '=',
     name: '@',
     icon: '@',
@@ -5091,6 +5092,7 @@ var UploadController = function () {
 
     _classCallCheck(this, UploadController);
 
+    this.ngDisabled = false;
     this.$timeout = $timeout;
     this.$element = $element;
     this.$http = $http;
@@ -5136,6 +5138,10 @@ var UploadController = function () {
     key: 'fileDropped',
     value: function fileDropped(file) {
       var _this2 = this;
+
+      if (this.ngDisabled) {
+        return;
+      }
 
       this.reset();
 
@@ -5194,7 +5200,7 @@ var UploadController = function () {
     value: function onDragEnter() {
       this.dragCounter++;
       if (this.dragCounter >= 1) {
-        this.isDroppable = true;
+        this.isDroppable = true && !this.ngDisabled;
       }
     }
   }, {
@@ -8141,7 +8147,7 @@ module.exports = "<div class=\"text-center tw-upload-droppable-box\"\n  ng-class
 /* 124 */
 /***/ (function(module, exports) {
 
-module.exports = "<div class=\"droppable\" ng-class=\"{\n  'droppable-sm': $ctrl.size ==='sm',\n  'droppable-md': $ctrl.size ==='md' || !$ctrl.size,\n  'droppable-lg': $ctrl.size ==='lg',\n  'droppable-dropping': $ctrl.isDroppable,\n  'droppable-processing': !$ctrl.isDone && ($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError),\n  'droppable-complete': $ctrl.isDone\n}\">\n  <div class=\"droppable-default-card\" aria-hidden=\"{{$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <div class=\"m-b-2\">\n        <img\n          ng-show=\"$ctrl.helpImage\"\n          ng-src=\"{{$ctrl.helpImage}}\"\n          alt=\"{{$ctrl.label}}\"\n          class=\"thumbnail text-xs-center\" />\n        <span ng-show=\"!$ctrl.helpImage\" class=\"icon icon-{{$ctrl.viewIcon}} icon-xxl\"></span>\n      </div>\n      <h4 class=\"m-b-1\" ng-if=\"$ctrl.label || $ctrl.description\">\n        {{$ctrl.label || $ctrl.description}}\n      </h4>\n      <p class=\"m-b-2\">{{$ctrl.placeholder || $ctrl.instructions}}</p>\n      <label class=\"btn btn-primary\">{{$ctrl.buttonText}}\n        <input tw-file-input\n          type=\"file\"\n          accept=\"{{$ctrl.accept}}\"\n          class=\"tw-droppable-input hidden\"\n\n          name=\"file-upload\"\n          on-user-input=\"$ctrl.onManualUpload()\"\n          ng-model=\"$ctrl.inputFile\" />\n        <!-- ng-change=\"$ctrl.onManualUpload()\" -->\n      </label>\n    </div>\n  </div>\n  <div class=\"droppable-processing-card droppable-card\"\n    aria-hidden=\"{{$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <h4 class=\"m-b-2\">\n        <span ng-if=\"$ctrl.isProcessing && $ctrl.processingText\">{{$ctrl.processingText}}</span>\n        <span ng-if=\"$ctrl.isSuccess && $ctrl.successText\">{{$ctrl.successText}}</span>\n        <span ng-if=\"$ctrl.isError && $ctrl.failureText\">{{$ctrl.failureText}}</span>\n      </h4>\n      <tw-process size=\"sm\" state=\"$ctrl.processingState\"\n        ng-if=\"($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError)\"></tw-process>\n    </div>\n  </div>\n  <div class=\"droppable-complete-card droppable-card\"\n    aria-hidden=\"{{!$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <div ng-if=\"!$ctrl.hasTranscluded && !$ctrl.isError\">\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.label\">\n          {{$ctrl.label}}\n        </h4>\n        <img\n          ng-if=\"$ctrl.isImage\"\n          src=\"data:image/png;base64,\n            iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=\"\n          ng-src=\"{{$ctrl.image}}\"\n          alt=\"OK\"\n          class=\"thumbnail m-b-3\" />\n        <span class=\"icon icon-pdf icon-xxl\" ng-if=\"!$ctrl.isImage\"></span>\n        <p class=\"text-ellipsis m-b-2\">{{$ctrl.fileName}}</p>\n      </div>\n      <div ng-if=\"!$ctrl.hasTranscluded && $ctrl.isError\">\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.isTooLarge\">{{$ctrl.tooLargeMessage}}</h4>\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.isWrongType\">{{$ctrl.wrongTypeText}}</h4>\n        <h4 class=\"m-b-2\" ng-if=\"!$ctrl.isTooLarge && $ctrl.errorMessage\">{{$ctrl.errorMessage}}</h4>\n        <span class=\"icon icon-alert icon-xxl text-danger m-b-1\"></span>\n      </div>\n      <div ng-if=\"$ctrl.hasTranscluded\" ng-transclude></div>\n      <p ng-if=\"$ctrl.cancelText\" class=\"m-t-2 m-b-0\">\n        <a href=\"\" ng-click=\"$ctrl.clear()\">{{$ctrl.cancelText}}</a>\n      </p>\n    </div>\n  </div>\n  <div class=\"droppable-dropping-card droppable-card\">\n    <div class=\"droppable-card-content\">\n      <h4 class=\"m-b-2\">Drop file to start upload</h4>\n      <div class=\"circle circle-sm\">\n        <span class=\"icon icon-add\"></span>\n      </div>\n      <p class=\"m-t-2 m-b-0\"></p>\n    </div>\n  </div>\n</div>'\n";
+module.exports = "<div class=\"droppable\" ng-class=\"{\n  'droppable-sm': $ctrl.size ==='sm',\n  'droppable-md': $ctrl.size ==='md' || !$ctrl.size,\n  'droppable-lg': $ctrl.size ==='lg',\n  'droppable-dropping': $ctrl.isDroppable,\n  'droppable-processing': !$ctrl.isDone && ($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError),\n  'droppable-complete': $ctrl.isDone\n}\">\n  <div class=\"droppable-default-card\" aria-hidden=\"{{$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <div class=\"m-b-2\">\n        <img\n          ng-show=\"$ctrl.helpImage\"\n          ng-src=\"{{$ctrl.helpImage}}\"\n          alt=\"{{$ctrl.label}}\"\n          class=\"thumbnail text-xs-center\" />\n        <span ng-show=\"!$ctrl.helpImage\" class=\"icon icon-{{$ctrl.viewIcon}} icon-xxl\"></span>\n      </div>\n      <h4 class=\"m-b-1\" ng-if=\"$ctrl.label || $ctrl.description\">\n        {{$ctrl.label || $ctrl.description}}\n      </h4>\n      <p class=\"m-b-2\">{{$ctrl.placeholder || $ctrl.instructions}}</p>\n      <label class=\"btn btn-primary\"  ng-class=\"{'disabled': $ctrl.ngDisabled}\"> {{$ctrl.buttonText}}\n        <input tw-file-input\n          type=\"file\"\n          accept=\"{{$ctrl.accept}}\"\n          class=\"tw-droppable-input hidden\"\n          ng-disabled=\"$ctrl.ngDisabled\"\n          name=\"file-upload\"\n          on-user-input=\"$ctrl.onManualUpload()\"\n          ng-model=\"$ctrl.inputFile\" />\n        <!-- ng-change=\"$ctrl.onManualUpload()\" -->\n      </label>\n    </div>\n  </div>\n  <div class=\"droppable-processing-card droppable-card\"\n    aria-hidden=\"{{$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <h4 class=\"m-b-2\">\n        <span ng-if=\"$ctrl.isProcessing && $ctrl.processingText\">{{$ctrl.processingText}}</span>\n        <span ng-if=\"$ctrl.isSuccess && $ctrl.successText\">{{$ctrl.successText}}</span>\n        <span ng-if=\"$ctrl.isError && $ctrl.failureText\">{{$ctrl.failureText}}</span>\n      </h4>\n      <tw-process size=\"sm\" state=\"$ctrl.processingState\"\n        ng-if=\"($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError)\"></tw-process>\n    </div>\n  </div>\n  <div class=\"droppable-complete-card droppable-card\"\n    aria-hidden=\"{{!$ctrl.isDone}}\">\n    <div class=\"droppable-card-content\">\n      <div ng-if=\"!$ctrl.hasTranscluded && !$ctrl.isError\">\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.label\">\n          {{$ctrl.label}}\n        </h4>\n        <img\n          ng-if=\"$ctrl.isImage\"\n          src=\"data:image/png;base64,\n            iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=\"\n          ng-src=\"{{$ctrl.image}}\"\n          alt=\"OK\"\n          class=\"thumbnail m-b-3\" />\n        <span class=\"icon icon-pdf icon-xxl\" ng-if=\"!$ctrl.isImage\"></span>\n        <p class=\"text-ellipsis m-b-2\">{{$ctrl.fileName}}</p>\n      </div>\n      <div ng-if=\"!$ctrl.hasTranscluded && $ctrl.isError\">\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.isTooLarge\">{{$ctrl.tooLargeMessage}}</h4>\n        <h4 class=\"m-b-2\" ng-if=\"$ctrl.isWrongType\">{{$ctrl.wrongTypeText}}</h4>\n        <h4 class=\"m-b-2\" ng-if=\"!$ctrl.isTooLarge && $ctrl.errorMessage\">{{$ctrl.errorMessage}}</h4>\n        <span class=\"icon icon-alert icon-xxl text-danger m-b-1\"></span>\n      </div>\n      <div ng-if=\"$ctrl.hasTranscluded\" ng-transclude></div>\n      <p ng-if=\"$ctrl.cancelText\" class=\"m-t-2 m-b-0\">\n        <a href=\"\" ng-click=\"$ctrl.clear()\">{{$ctrl.cancelText}}</a>\n      </p>\n    </div>\n  </div>\n  <div class=\"droppable-dropping-card droppable-card\">\n    <div class=\"droppable-card-content\">\n      <h4 class=\"m-b-2\">Drop file to start upload</h4>\n      <div class=\"circle circle-sm\">\n        <span class=\"icon icon-add\"></span>\n      </div>\n      <p class=\"m-t-2 m-b-0\"></p>\n    </div>\n  </div>\n</div>\n";
 
 /***/ }),
 /* 125 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tw-styleguide-components",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.component.js
+++ b/src/forms/upload/upload.component.js
@@ -6,6 +6,7 @@ const Upload = {
   template,
   transclude: true,
   bindings: {
+    ngDisabled: '<',
     ngModel: '=',
     name: '@',
     icon: '@',

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -10,6 +10,7 @@ class UploadController {
     $q,
     $attrs
   ) {
+    this.ngDisabled = false;
     this.$timeout = $timeout;
     this.$element = $element;
     this.$http = $http;
@@ -52,6 +53,10 @@ class UploadController {
   }
 
   fileDropped(file) {
+    if (this.ngDisabled) {
+      return;
+    }
+
     this.reset();
 
     this.isImage_instant = (file.type && file.type.indexOf('image') > -1);
@@ -110,7 +115,7 @@ class UploadController {
   onDragEnter() {
     this.dragCounter++;
     if (this.dragCounter >= 1) {
-      this.isDroppable = true;
+      this.isDroppable = true && !this.ngDisabled;
     }
   }
   onDragLeave() {

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -10,7 +10,6 @@ class UploadController {
     $q,
     $attrs
   ) {
-    this.ngDisabled = false;
     this.$timeout = $timeout;
     this.$element = $element;
     this.$http = $http;

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -20,12 +20,12 @@
         {{$ctrl.label || $ctrl.description}}
       </h4>
       <p class="m-b-2">{{$ctrl.placeholder || $ctrl.instructions}}</p>
-      <label class="btn btn-primary">{{$ctrl.buttonText}}
+      <label class="btn btn-primary"  ng-class="{'disabled': $ctrl.ngDisabled}"> {{$ctrl.buttonText}}
         <input tw-file-input
           type="file"
           accept="{{$ctrl.accept}}"
           class="tw-droppable-input hidden"
-
+          ng-disabled="$ctrl.ngDisabled"
           name="file-upload"
           on-user-input="$ctrl.onManualUpload()"
           ng-model="$ctrl.inputFile" />
@@ -83,4 +83,4 @@
       <p class="m-t-2 m-b-0"></p>
     </div>
   </div>
-</div>'
+</div>


### PR DESCRIPTION
**Changes:**
- Fixed small cosmetic issue the extra `quote mark` in the end of the template (upload.html),
- added `ngDisabled` handling to dropDown (drag and drop) component, input and label elements,
- added dist directory (built) files,
- bumped minor version (package.json),

**Questions:**
- upload.controller.js is the code changed good there?
- `npm test `now is failing

Tested locally and manually UI test and worked fine in every case.
(disabled, not disabled, later changing the disabled flag)

`Failing tests has no relation to these changes, but still concerning (maybe because of different locale settings
`
```
FAILED TESTS:
  DateFormat filter,
    Given the locale is en-GB
      and a short format is requested
        ✖ should shorten the formatted value
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '5th .No 2016' to be '5th Nov 2016'.
        /Users/peter.czuczor/Projects/styleguide-components/src/formatting/date-format/date-format.filter.spec.js:85:31

  DateLookup,
    given the component is initialised
      when locale attribute is passed
        ✖ should populate vm.months with default English months
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '.January.' to be 'January'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:921:45
        forEach@[native code]
        expectDateMonthsToBeDefault@/Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:920:27
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:226:38

      when shortDate==true
        ✖ should show short month name
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '10th .Ja 2000' to be '10th Jan 2000'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:239:71

    when the component is already initialised
      given locale changes
        ✖ should populate $ctrl.months with default English months
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '.January.' to be 'January'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:921:45
        forEach@[native code]
        expectDateMonthsToBeDefault@/Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:920:27
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:515:40

        ✖ should show day before month if locale not US
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '1 .January. 2000' to equal '1 January 2000'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date-lookup/date-lookup.spec.js:525:76

  Date
    init
      when locale attribute is passed
        ✖ should populate $ctrl.months with default English months
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '.January.' to be 'January'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:832:49
        forEach@[native code]
        expectDateMonthsToBeDefault@/Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:830:27
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:295:38

      when incorrect locale  passed
        ✖ should populate $ctrl.dateMonths with default English months
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '.January.' to be 'January'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:832:49
        forEach@[native code]
        expectDateMonthsToBeDefault@/Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:830:27
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:320:36

    watchers on shared $scope
      locale
        ✖ should populate $ctrl.dateMonths with default English months
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '.January.' to be 'January'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:832:49
        forEach@[native code]
        expectDateMonthsToBeDefault@/Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:830:27
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/date/date.spec.js:651:38

  Definition list
    when given a date field
      ✖ should display the formatted date value
        PhantomJS 2.1.1 (Mac OS X 0.0.0)
      Expected '1 .January. 2000' to be '1 January 2000'.
      /Users/peter.czuczor/Projects/styleguide-components/src/forms/definition-list/definition-list.spec.js:81:49

    when given requirements with nested field groups
      when given a date field
        ✖ should display the formatted date value
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected '1 .January. 2000' to be '1 January 2000'.
        /Users/peter.czuczor/Projects/styleguide-components/src/forms/definition-list/definition-list.spec.js:233:51

  TwDateService test
    when English locale
       and short format
        ✖ should provide the correct month names
          PhantomJS 2.1.1 (Mac OS X 0.0.0)
        Expected $[0] = '.Ja' to equal 'Jan'.
        Expected $[1] = '.Fe' to equal 'Feb'.
        Expected $[2] = '.Ma' to equal 'Mar'.
        Expected $[3] = '.Ap' to equal 'Apr'.
        Expected $[4] = '.Ma' to equal 'May'.
        Expected $[5] = '.Ju' to equal 'June'.
        Expected $[6] = '.Ju' to equal 'July'.
        Expected $[7] = '.Au' to equal 'Aug'.
        Expected $[8] = '.Se' to equal 'Sep'.
        Expected $[9] = '.Oc' to equal 'Oct'.
        Expected $[10] = '.No' to equal 'Nov'.
        Expected $[11] = '.De' to equal 'Dec'.
        /Users/peter.czuczor/Projects/styleguide-components/src/services/date/date.spec.js:23:35
```

**Update 12.13** Failed tests root cause should be fixed with his:
- https://github.com/transferwise/styleguide-components/pull/153