### PR TITLE
Add text-word-break to Descripton List elements to avoid overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.2.1
+## Add text-word-break to definition list elements to stop overflowing over other elements
+
 # v3.2.0
 ## Add a submit button component
 Provides loading indication and success/failure feedback using twProcess.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.1.2",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1290,7 +1290,7 @@
       }
     },
     "bootstrap": {
-      "version": "git+https://github.com/transferwise/bootstrap.git#1bd8f1821846ab57ac0175b24eb0ece7af013b82",
+      "version": "git+https://github.com/transferwise/bootstrap.git#a135aac57c06e25795410dd4b1496f2c9bd8e4c6",
       "dev": true
     },
     "brace-expansion": {
@@ -2075,7 +2075,7 @@
       }
     },
     "currency-flags": {
-      "version": "git+https://github.com/transferwise/currency-flags.git#49868469160852b34e2b7d30351b50ec3ae77d86",
+      "version": "git+https://github.com/transferwise/currency-flags.git#432be37e74015cc9875c50c9cbd3586528d37d89",
       "dev": true
     },
     "currently-unhandled": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/definition-list/definition-list.html
+++ b/src/forms/definition-list/definition-list.html
@@ -13,7 +13,7 @@
 
     <dl ng-if="!field.group">
       <dt ng-bind="field.title"></dt>
-      <dd ng-switch="field.control">
+      <dd ng-switch="field.control" class="text-word-break">
         <span ng-switch-when="select|radio" ng-switch-when-separator="|">
           {{ $ctrl.getValueLabel(field.values, $ctrl.model[key]) }}
         </span>
@@ -40,7 +40,7 @@
     <!-- Start old 'nested group' style -->
     <dl ng-if="field.group">
       <dt ng-bind="field.title"></dt>
-      <dd>
+      <dd class="text-word-break">
         <span ng-repeat="fieldSection in field.group">
           <span ng-switch="fieldSection.control">
             <span ng-switch-when="select|radio" ng-switch-when-separator="|">


### PR DESCRIPTION
Was:
![image](https://user-images.githubusercontent.com/8721312/39252039-6b0f53ac-48ad-11e8-89ab-9d54e6639153.png)


Will:
![image](https://user-images.githubusercontent.com/8721312/39252017-5fe17be0-48ad-11e8-9f1f-808d137cbfcb.png)
