### PR TITLE
remove redundant upload switch case from form-control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.5.1
+## remove redundant upload switch case from form-control
+removed redundant switch case 'upload' from form-control component since it was never used
+
 # v3.5.0
 ## Add new support to the pop over service for the new popover placements
 Changing the popover service API. Adding three new placements for the top, right, bottom and left initial placements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.4.4
+## remove redundant upload switch case from form-control
+removed redundant switch case 'upload' from form-control component since it was never used
+
 # v3.4.3
 ## onRefreshRequirements triggering changes
 onRefreshRequirements is now triggered in onChange for all field types.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/form-control/form-control.html
+++ b/src/forms/form-control/form-control.html
@@ -53,7 +53,7 @@
     ></tw-select>
   </div>
 
-  <div ng-switch-when="file|upload" ng-switch-when-separator="|">
+  <div ng-switch-when="file">
     <tw-upload
       name="{{$ctrl.name}}"
       label="{{$ctrl.label}}"

--- a/src/forms/form-control/form-control.spec.js
+++ b/src/forms/form-control/form-control.spec.js
@@ -205,6 +205,28 @@ describe('FormControl', function() {
     }, 1);
   });
 
+  describe('type: file - validation', function() {
+    beforeEach(function() {
+      $scope.model = null;
+      formGroup = compileTemplate(
+        "<div class='form-group'> \
+          <label class='control-label'></label> \
+          <tw-form-control type='file' \
+            ng-model='model' \
+            ng-focus='onFocus()' \
+            ng-blur='onBlur()' \
+            ng-change='onChange(value)' \
+            required> \
+          </tw-form-control> \
+        </div>"
+      );
+      element = formGroup.querySelector('tw-form-control');
+    });
+    it('should render twUpload', function() {
+      expect(element.querySelector('tw-upload')).toBeTruthy();
+    });
+  });
+
   describe('type: date', function() {
     var dayInput, yearInput;
     beforeEach(function() {

--- a/src/forms/form-control/form-control.spec.js
+++ b/src/forms/form-control/form-control.spec.js
@@ -205,28 +205,6 @@ describe('FormControl', function() {
     }, 1);
   });
 
-  describe('type: upload - validation', function() {
-    beforeEach(function() {
-      $scope.model = null;
-      formGroup = compileTemplate(
-        "<div class='form-group'> \
-          <label class='control-label'></label> \
-          <tw-form-control type='upload' \
-            ng-model='model' \
-            ng-focus='onFocus()' \
-            ng-blur='onBlur()' \
-            ng-change='onChange(value)' \
-            required> \
-          </tw-form-control> \
-        </div>"
-      );
-      element = formGroup.querySelector('tw-form-control');
-    });
-    it('should render twUpload', function() {
-      expect(element.querySelector('tw-upload')).toBeTruthy();
-    });
-  });
-
   describe('type: date', function() {
     var dayInput, yearInput;
     beforeEach(function() {


### PR DESCRIPTION
Remove the upload switch case from form-control since it is redundant.
Looking at the getControlType logic in https://github.com/transferwise/styleguide-components/blob/master/src/services/requirements/requirements.service.js#L379 that is used by the field component, 'upload' is never returned and so the field component will never pass down 'upload' type to form-control, making it redundant.