### PR TITLE
fix(upload): Unable to remove file if cancelText is not provided [USD-3124]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.6.1
+## Allow user to remove a chosen file from Upload form
+Previous behavior required `cancelText` to be passed into the
+upload component for the "cancel" link to render. This change provides a placeholder "X" icon when no `cancelText` is provided.
+
 # v3.6.0
 ## In requirements, help information is now nested, 'required' uses JSON schema approach.
 helpText, helpList & helpImage are now expected to be nested as

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -71,8 +71,21 @@
         <span class="icon icon-alert icon-xxl text-danger m-b-1"></span>
       </div>
       <div ng-if="$ctrl.hasTranscluded" ng-transclude></div>
-      <p ng-if="$ctrl.cancelText" class="m-t-2 m-b-0">
-        <a href="" ng-click="$ctrl.clear()">{{$ctrl.cancelText}}</a>
+      <p class="m-t-2 m-b-0">
+        <a href="" ng-click="$ctrl.clear()">
+          <svg 
+            ng-if="!$ctrl.cancelText" 
+            viewBox="0 0 24 24" 
+            fill="#00b9ff"
+            xmlns="http://www.w3.org/2000/svg"
+            height="25">
+            <path d="M12 23a11 11 0 1 1 11-11 11 11 0 0 1-11 11zm0-21a10 10 0 1 0 10 10A10 10 0 0 0 12 2z"></path>
+            <path
+              d="M16.85 7.85l-.71-.7L12 11.29 7.85 7.15l-.71.7L11.29 12l-4.15 4.15.71.7L12 12.71l4.14 4.14.71-.7L12.7 12l4.15-4.15z">
+            </path>
+          </svg>
+          {{$ctrl.cancelText}}
+        </a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
When `cancelText` is not provided to the upload component: the user has no way to change the file they uploaded.

**Current UI, with `cancelText` _(this behavior will remain the same)_:**
<img width="387" alt="with cancelText" src="https://user-images.githubusercontent.com/45621596/53358748-25974f80-38ff-11e9-9e91-22ffcd61e8f2.png">

**Updated UI, with missing `cancelText`:**
<img width="388" alt="missing cancelText" src="https://user-images.githubusercontent.com/45621596/53589390-40ff9600-3b5d-11e9-9ee2-53468f9f8d20.png">


