### PR TITLE
Change requirements help format & align with JSON schema for 'required'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+# v3.6.0
+## In requirements, help information is now nested, 'required' uses JSON schema approach.
+helpText, helpList & helpImage are now expected to be nested as
+```
+help: {
+  message: "...",
+  list: [...],
+  image: "..."
+}
+```
+Required is now supplied as per JSON schema spec so as an array on the object
+
+```
+{
+  type: "object",
+  required: ["name"],
+  properties: {
+    name: { type: "string" }
+  }
+}
+```
+Not as a boolean within the property
+
+```
+{
+  type: "object",
+  properties: {
+    name: { type: "string", required: true }
+  }
+}
+```
+twField therefore adds a property 'required' as the data is no longer within the 'field' data.
+
+```
+<tw-field field="$ctrl.field" required="true"></tw-field>
+```
+
 # v3.5.10
 ## Add a callback for model changes on requirements form
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.5.10",
+  "version": "3.6.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/field/field.component.js
+++ b/src/forms/field/field.component.js
@@ -8,13 +8,15 @@ const Field = {
     name: '@',
     model: '=',
     initialField: '<field',
-    uploadOptions: '<',
     locale: '@',
+    required: '<',
+    uploadOptions: '<',
     changeHandler: '&?onChange',
     focusHandler: '&?onFocus',
     blurHandler: '&?onBlur',
     errorMessage: '<',
-    warningMessage: '<'
+    warningMessage: '<',
+    validationMessages: '<'
   }
 };
 

--- a/src/forms/field/field.controller.js
+++ b/src/forms/field/field.controller.js
@@ -6,6 +6,7 @@ class FieldController {
   $onChanges(changes) {
     if (changes.initialField) {
       this.field = copyJSON(this.initialField);
+
       this.control = this.field.control ? this.field.control :
         this.RequirementsService.getControlType(changes.initialField.currentValue);
 
@@ -14,12 +15,21 @@ class FieldController {
         this.RequirementsService.prepValuesAsync(this.field, {});
       }
 
+      if (this.required && !this.field.required) {
+        this.field.required = true;
+      }
+
       // If the field is required, and only allows one value, set it to that
       if (this.field.required && this.field.enum && this.field.enum.length === 1) {
         this.model = this.field.enum[0];
       }
+
       if (this.field.default && !this.model) {
         this.model = this.field.default;
+      }
+
+      if (this.validationMessages && !field.validationMessages) {
+        field.validationMessages = this.validationMessages;
       }
     }
   }

--- a/src/forms/field/field.controller.js
+++ b/src/forms/field/field.controller.js
@@ -15,12 +15,8 @@ class FieldController {
         this.RequirementsService.prepValuesAsync(this.field, {});
       }
 
-      if (this.required && !this.field.required) {
-        this.field.required = true;
-      }
-
       // If the field is required, and only allows one value, set it to that
-      if (this.field.required && this.field.enum && this.field.enum.length === 1) {
+      if (this.required && this.field.enum && this.field.enum.length === 1) {
         this.model = this.field.enum[0];
       }
 

--- a/src/forms/field/field.controller.js
+++ b/src/forms/field/field.controller.js
@@ -28,8 +28,8 @@ class FieldController {
         this.model = this.field.default;
       }
 
-      if (this.validationMessages && !field.validationMessages) {
-        field.validationMessages = this.validationMessages;
+      if (this.validationMessages && !this.field.validationMessages) {
+        this.field.validationMessages = this.validationMessages;
       }
     }
   }

--- a/src/forms/field/field.demo.html
+++ b/src/forms/field/field.demo.html
@@ -205,18 +205,21 @@ on-change="changeHandler(value)"&gt;
   name="stringProperty"
   field="$ctrl.stringValidation"
   model="$ctrl.validationModel.stringProperty"
+  required="true"
   on-change="$ctrl.log(value)">
 </field-example>
 <field-example
   name="numberProperty"
   field="$ctrl.numberValidation"
   model="$ctrl.validationModel.numberProperty"
+  required="true"
   on-change="$ctrl.log(value)">
 </field-example>
 <field-example
   name="dateProperty"
   field="$ctrl.dateValidation"
   model="$ctrl.validationModel.dateProperty"
+  required="true"
   on-change="$ctrl.log(value)">
 </field-example>
 

--- a/src/forms/field/field.demo.js
+++ b/src/forms/field/field.demo.js
@@ -12,6 +12,7 @@ export default angular
       name: '@',
       model: '=',
       field: '<',
+      required: '<',
       errorMessage: '<',
       warningMessage: '<',
       onFocusHandler: '&?onFocus',
@@ -42,6 +43,7 @@ export default angular
           name="$ctrl.name"
           model="$ctrl.model"
           field="$ctrl.field"
+          required="$ctrl.required"
           error-message="$ctrl.errorMessage"
           warning-message="$ctrl.warningMessage"
           on-focus="$ctrl.onFocus()"
@@ -52,7 +54,8 @@ export default angular
       <div class="col-md-6" ng-class="{'p-t-3': $ctrl.field.format !== 'base64url'}">
 <pre>&lt;tw-field
   name="{{ $ctrl.name }}"
-  model="{{ $ctrl.model }}"<span ng-if="$ctrl.errorMessage">
+  model="{{ $ctrl.model }}"<span ng-if="$ctrl.required">
+  required="{{ $ctrl.required }}"</span><span ng-if="$ctrl.errorMessage">
   error-message="'{{ $ctrl.errorMessage }}'"</span><span ng-if="$ctrl.warningMessage">
   warning-message="'{{ $ctrl.warningMessage }}'"</span><span ng-if="$ctrl.onFocusHandler">
   on-focus="console.log('focus')"</span><span ng-if="$ctrl.onBlurHandler">
@@ -203,7 +206,6 @@ function fieldDocsController() {
     type: 'string',
     title: 'String validation',
     placeholder: 'Please enter text',
-    required: true,
     pattern: '^[A-Z]*$',
     minLength: 4,
     maxLength: 6,
@@ -218,7 +220,6 @@ function fieldDocsController() {
     type: 'number',
     title: 'Number control',
     placeholder: 'Please enter number',
-    required: true,
     minimum: 10,
     maximum: 99,
     validationMessages: {
@@ -231,7 +232,6 @@ function fieldDocsController() {
     type: 'string',
     format: 'date',
     title: 'Date control',
-    required: true,
     minimum: '2000-01-01',
     maximum: '2020-01-01',
     validationMessages: {
@@ -267,23 +267,29 @@ function fieldDocsController() {
     type: 'string',
     title: 'Help text',
     placeholder: 'Please enter text',
-    helpText: 'Some helpful information'
+    help: {
+      message: 'Some helpful information'
+    }
   };
   this.helpList = {
     type: 'string',
     title: 'Help list',
     placeholder: 'Please enter number',
-    helpList: [
-      'Make sure of this',
-      'And this',
-      'And avoid this'
-    ]
+    help: {
+      list: [
+        'Make sure of this',
+        'And this',
+        'And avoid this'
+      ]
+    }
   };
   this.helpImage = {
     type: 'string',
     title: 'Help image',
     placeholder: 'Please enter number',
-    helpImage: 'images/captcha.png'
+    help: {
+      image: 'images/captcha.png'
+    }
   };
 
   // Presentation options

--- a/src/forms/field/field.html
+++ b/src/forms/field/field.html
@@ -25,7 +25,7 @@
     ng-focus="$ctrl.onFocus()"
     ng-blur="$ctrl.onBlur()"
     ng-change="$ctrl.onChange($ctrl.model)"
-    ng-required="$ctrl.field.required"
+    ng-required="$ctrl.required"
     ng-disabled="$ctrl.field.disabled"
     tw-minlength="$ctrl.field.minlength || $ctrl.field.minLength"
     tw-maxlength="$ctrl.field.maxlength || $ctrl.field.maxLength"

--- a/src/forms/field/field.html
+++ b/src/forms/field/field.html
@@ -58,21 +58,21 @@
     {{ $ctrl.warningMessage }}
   </div>
 
-  <div ng-if="$ctrl.field.helpText || $ctrl.field.helpList || $ctrl.field.helpImage"
+  <div ng-if="$ctrl.field.help"
     class="alert alert-focus"
     ng-class="{
       'alert-detach': $ctrl.isFeedbackDetached($ctrl.control)
     }">
-    <span ng-if="$ctrl.field.helpText">
-      {{ $ctrl.field.helpText }}
+    <span ng-if="$ctrl.field.help.message">
+      {{ $ctrl.field.help.message }}
     </span>
-    <ul ng-if="$ctrl.field.helpList" class="list-unstyled">
-      <li ng-repeat="helpMessage in $ctrl.field.helpList">{{ helpMessage }}</li>
+    <ul ng-if="$ctrl.field.help.list" class="list-unstyled">
+      <li ng-repeat="helpMessage in $ctrl.field.help.list">{{ helpMessage }}</li>
     </ul>
     <img
-      ng-if="$ctrl.field.helpImage && $ctrl.control !== 'file'"
-      ng-src="{{$ctrl.field.helpImage}}"
-      alt="{{$ctrl.field.title}}"
+      ng-if="$ctrl.field.help.image && $ctrl.control !== 'file'"
+      ng-src="{{$ctrl.field.help.image}}"
+      alt="{{ $ctrl.field.title }}"
       class="thumbnail m-y-2" />
   </div>
 </div>

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -199,7 +199,8 @@ describe('Field', function() {
 
   describe('when the field is required and has only one enum value', function() {
     beforeEach(function() {
-      $scope.options = { type: "string", enum: ['valid'], required: true };
+      $scope.options = { type: "string", enum: ['valid'] };
+      $scope.required = true;
       $scope.model = 'invalid';
       element = getCompiledDirectiveElement();
     });
@@ -320,6 +321,7 @@ describe('Field', function() {
         name='keyName' \
         model='model' \
         field='options' \
+        required='required' \
         validation-messages='validationMessages' \
         error-message='errorMessage' \
         on-change='onChange()' \

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -225,7 +225,22 @@ describe('Field', function() {
     it('should render the message', function() {
       expect(element.querySelector('.error-provided').innerText.trim()).toBe('Custom error');
     });
+
+    describe('and the value is changed', function() {
+      beforeEach(function() {
+        var input = element.querySelector('input');
+        input.value = 'something';
+        input.dispatchEvent(new Event('input'));
+        $timeout.flush();
+      });
+      it('should remove the error message', function() {
+        var errorMessages = element.querySelector('.error-messages');
+        expect(formGroup.classList).not.toContain('has-error');
+        expect(errorMessages).toBeFalsy();
+      });
+    });
   });
+
   describe('when given hidden: true', function() {
     beforeEach(function() {
       $scope.options = { type: "string", hidden: true };

--- a/src/forms/fieldset/fieldset.html
+++ b/src/forms/fieldset/fieldset.html
@@ -22,6 +22,7 @@
 
         warning-message="$ctrl.warningMessages[key]"
         error-message="$ctrl.errorMessages[key]"
+        validation-messages="$ctrl.validationMessages"
 
         on-change="$ctrl.fieldChange(value, key, field)"
         on-focus="$ctrl.fieldFocus(key, field)"
@@ -41,6 +42,7 @@
 
         warning-messages="$ctrl.warningMessages[key]"
         error-messages="$ctrl.errorMessages[key]"
+        validation-messages="$ctrl.validationMessages"
 
         on-refresh-requirements="$ctrl.refreshRequirements()"
         on-field-change="$ctrl.fieldChange(value, key, field)"

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -158,12 +158,6 @@ describe('Fieldset', function() {
           }
         });
       });
-      it('should clear the error message', function() {
-        var formGroup = element.querySelector('.tw-field-textInput');
-        var errorMessages = formGroup.querySelector('.error-messages');
-        expect(formGroup.classList).not.toContain('has-error');
-        expect(errorMessages).toBeFalsy();
-      });
     });
   });
 

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -378,11 +378,11 @@ function RequirementsService($http) {
   };
 
   this.prepValidationMessages = (field) => {
-    if (field.validationMessages.minimum) {
+    if (field.validationMessages && field.validationMessages.minimum) {
       field.validationMessages.min = field.validationMessages.minimum;
       delete field.validationMessages.minimum;
     }
-    if (field.validationMessages.maximum) {
+    if (field.validationMessages && field.validationMessages.maximum) {
       field.validationMessages.max = field.validationMessages.maximum;
       delete field.validationMessages.maximum;
     }
@@ -394,12 +394,15 @@ function RequirementsService($http) {
     }
     if (field.helpText) {
       field.help.message = field.helpText;
+      delete field.helpText;
     }
     if (field.helpImage) {
       field.help.image = field.helpImage;
+      delete field.helpImage;
     }
     if (field.list) {
       field.help.list = field.helpList;
+      delete field.helpList;
     }
   };
 

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -377,7 +377,7 @@ function RequirementsService($http) {
     return data;
   };
 
-  this.prepValidationMessages = (field, validationMessages) => {
+  this.prepValidationMessages = (field) => {
     if (field.validationMessages.minimum) {
       field.validationMessages.min = field.validationMessages.minimum;
       delete field.validationMessages.minimum;
@@ -388,8 +388,8 @@ function RequirementsService($http) {
     }
   };
 
-  this.prepHelp = field => {
-    if (!field.help && (field.helpText ||  field.helpImage || field.helpList)) {
+  this.prepHelp = (field) => {
+    if (!field.help && (field.helpText || field.helpImage || field.helpList)) {
       field.help = {};
     }
     if (field.helpText) {

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -61,6 +61,7 @@ function RequirementsService($http) {
     this.prepPattern(preparedField);
     this.prepValuesAsync(preparedField, model);
     this.prepValidationMessages(preparedField, validationMessages);
+    this.prepHelp(preparedField);
 
     return preparedField;
   };
@@ -377,15 +378,6 @@ function RequirementsService($http) {
   };
 
   this.prepValidationMessages = (field, validationMessages) => {
-    field.validationMessages = field.validationMessages ?
-      field.validationMessages :
-      validationMessages;
-
-    if (!field.validationMessages) {
-      delete field.validationMessages;
-      return;
-    }
-
     if (field.validationMessages.minimum) {
       field.validationMessages.min = field.validationMessages.minimum;
       delete field.validationMessages.minimum;
@@ -393,6 +385,21 @@ function RequirementsService($http) {
     if (field.validationMessages.maximum) {
       field.validationMessages.max = field.validationMessages.maximum;
       delete field.validationMessages.maximum;
+    }
+  };
+
+  this.prepHelp = field => {
+    if (!field.help && (field.helpText ||  field.helpImage || field.helpList)) {
+      field.help = {};
+    }
+    if (field.helpText) {
+      field.help.message = field.helpText;
+    }
+    if (field.helpImage) {
+      field.help.image = field.helpImage;
+    }
+    if (field.list) {
+      field.help.list = field.helpList;
     }
   };
 

--- a/src/services/requirements/requirements.spec.js
+++ b/src/services/requirements/requirements.spec.js
@@ -85,7 +85,9 @@ describe('Requirements Service', function() {
           type: "string",
           control: "text",
           placeholder: "Example",
-          helpText: "Tool tip",
+          help: {
+            message: "Tool tip"
+          },
           minimum: 1,
           maximum: 2,
           pattern: "[A-Z]"


### PR DESCRIPTION
helpText, helpList & helpImage are now expected to be nested as 
```
help: {
  message: "...",
  list: [...],
  image: "..."
}
```

Required is now supplied as per JSON schema spec so as an array on the object
```
{
  type: "object",
  required: ["name"],
  properties: {
    name: { type: "string" }
  }
}
```
Not as a boolean within the property
```
{
  type: "object",
  properties: {
    name: { type: "string", required: true }
  }
}
```
twField therefore adds a property 'required' as the data is no longer within the 'field' data.
```
<tw-field field="$ctrl.field" required="true"></tw-field>
```