### PR TITLE
ASIA-2103: Improve tw-select performance when it has a large number of options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.8.3
+## Improve tw-select performance with large option lists
+
 # v3.8.2
 ## Adjust date time format
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.demo.js
+++ b/src/forms/select/select.demo.js
@@ -104,8 +104,8 @@ export default angular
           long: [{ header: 'example header' }]
         }
       };
-      for (let i = 0; i < 999; i++) {
-        this.select.options.long.push({ value: String(i), label: String(i) });
+      for (let i = 1; i <= 3000; i++) {
+        this.select.options.long.push({ value: `option-${i}`, label: `Optiony Option ${i}` });
       }
 
       this.hideOptions = [

--- a/src/forms/select/select.html
+++ b/src/forms/select/select.html
@@ -113,7 +113,7 @@
         'dropdown-header': option.header,
         'tw-select-option': !option.header && !option.disabled
       }">
-      <span ng-if="option.header" class="text-ellipsis">{{option.header}}</span>
+      <span ng-if="option.header" class="text-ellipsis" ng-click="$event.stopPropagation()">{{option.header}}</span>
       <a href=""
         ng-if="!option.header"
         ng-click="$ctrl.optionClick(option, $event)"
@@ -148,6 +148,16 @@
           ng-if="option.note" class="tw-select-note small m-l-1">{{option.note}}</span><span
           ng-if="option.secondary"
           class="tw-select-secondary small text-ellipsis">{{option.secondary}}</span>
+      </a>
+    </li>
+
+    <li ng-if="$ctrl.hasMoreOptionsToReveal">
+      <a href=""
+        ng-click="$ctrl.revealMoreOptions($event)"
+        class="tw-select-load-more"
+        tabindex="-1"
+        tw-focusable >
+        ...
       </a>
     </li>
 

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -25,6 +25,7 @@ describe('Select', function() {
   var OPTION_CIRCLE_TEXT_SELECTOR = '.dropdown-menu .tw-select-circle-text';
   var OPTION_CIRCLE_ICON_SELECTOR = '.dropdown-menu .circle .icon';
   var OPTION_DISABLED_SELECTOR = '.dropdown-menu .disabled';
+  var OPTION_LOAD_MORE_SELECTOR = '.dropdown-menu .tw-select-load-more';
 
   beforeEach(module('tw.styleguide.forms'));
   beforeEach(module('tw.styleguide.services'));
@@ -508,22 +509,50 @@ describe('Select', function() {
     });
   });
 
-  describe('when a long list of options is supplied (and no filter)', function() {
-    var filterInput;
+  describe('when a long list of options is supplied', function() {
+    var template, component;
     beforeEach(function() {
       $scope.options = OPTIONS_LONG;
       $scope.ngModel = '1';
-      var template = " \
+      template = " \
         <tw-select \
           options='options' \
           ng-model='ngModel'> \
         </tw-select>";
       component = getComponent($scope, template);
-      filterInput = component.find(FILTER_INPUT_SELECTOR)[0];
     });
-    it('should automatically show the search input', function() {
+
+    it('should always show the search input (without having to specify the filter attribute)', function() {
+      var filterInput = component.find(FILTER_INPUT_SELECTOR)[0];
       expect(filterInput).toBeTruthy();
     });
+
+    it('should limit the number of options initially shown', function () {
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(50);
+    });
+
+    it('should show a "..." option at the end to load more options', function () {
+      expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(1);
+    });
+
+    it('should load more options when "..." is clicked', function () {
+      component.find(OPTION_LOAD_MORE_SELECTOR).click();
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(100);
+      expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(1);
+
+      component.find(OPTION_LOAD_MORE_SELECTOR).click();
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(101); // List exhausted.
+      expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(0);
+    });
+
+    it('does not show a "..." when there aren\'t any more options to load', function () {
+      $scope.options = OPTIONS_LONG.slice(0, 50);
+      component = getComponent($scope, template);
+
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(50);
+      expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(0);
+    });
+
   });
 
   describe('when a filter attribute is supplied', function() {
@@ -1331,20 +1360,14 @@ describe('Select', function() {
     searchable: "Searchable"
   }];
 
-  var OPTIONS_LONG = [
-    { value: '0',label: 'Zero' },
-    { value: '1', label: 'One' },
-    { value: '2', label: 'Two' },
-    { value: '3', label: 'Three'},
-    { value: '4', label: 'Four'},
-    { value: '5', label: 'Five'},
-    { value: '6', label: 'Six'},
-    { value: '7', label: 'Seven'},
-    { value: '8', label: 'Eight'},
-    { value: '9', label: 'Nine'},
-    { value: '10', label: 'Ten'},
-    { value: '11', label: 'Eleven'},
-    { value: '12', label: 'Twelve'},
-    { value: '13', label: 'Thirteen'}
-  ];
+  // 101 options.
+  var OPTIONS_LONG = (function () {
+    var options = [];
+
+    for (var i = 1; i <= 101; ++i) {
+      options.push({ value: '' + i, label: 'Optiony Option ' + i });
+    }
+
+    return options;
+  })();
 });


### PR DESCRIPTION
We were informed that the UI would freeze when someone was trying to add a Japanese recipient for a to-JPY transfer: https://transferwise.slack.com/archives/C0JNUL7RD/p1558104250003800. It turns out Japan would generate the largest amount of entries for bank or branch codes (over 3000). There are multiple things that can be improved but one of them was that `tw-select` would create 3000 elements on the page.

This PR improves `tw-select` for when there's such a high number of options. Specifically, it will only render the first 50 entries, with a `...` at the bottom. Click it and the list expands to 100. Click it again and the list expands to 150 etc. The `...` doesn't appear if there's less than 51 options.