### PR TITLE
Increase tw-select large option size from 50 to 300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.8.4
+## Increase the tw-select large option size from 50 to 300
+
 # v3.8.3
 ## Improve tw-select performance with large option lists
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.2",
+  "version": "3.8.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1233,7 +1233,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -3627,8 +3626,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3649,14 +3647,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3671,20 +3667,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3801,8 +3794,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3814,7 +3806,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3829,7 +3820,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3837,14 +3827,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3863,7 +3851,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3944,8 +3931,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3957,7 +3943,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4043,8 +4028,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4080,7 +4064,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4100,7 +4083,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4144,14 +4126,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4582,8 +4562,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -26,7 +26,7 @@ class SelectController {
 
     this.responsiveClasses = responsiveClasses;
 
-    this.optionsPageSize = 50;
+    this.optionsPageSize = 300;
     this.numberOfOptionsRevealed = this.optionsPageSize; // Init.
     this.hasMoreOptionsToReveal = false;
 

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -528,7 +528,7 @@ describe('Select', function() {
     });
 
     it('should limit the number of options initially shown', function () {
-      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(50);
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(300);
     });
 
     it('should show a "..." option at the end to load more options', function () {
@@ -537,19 +537,19 @@ describe('Select', function() {
 
     it('should load more options when "..." is clicked', function () {
       component.find(OPTION_LOAD_MORE_SELECTOR).click();
-      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(100);
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(600);
       expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(1);
 
       component.find(OPTION_LOAD_MORE_SELECTOR).click();
-      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(101); // List exhausted.
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(601); // List exhausted.
       expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(0);
     });
 
     it('does not show a "..." when there aren\'t any more options to load', function () {
-      $scope.options = OPTIONS_LONG.slice(0, 50);
+      $scope.options = OPTIONS_LONG.slice(0, 300);
       component = getComponent($scope, template);
 
-      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(50);
+      expect(component.find(LIST_ITEMS_SELECTOR).length).toBe(300);
       expect(component.find(OPTION_LOAD_MORE_SELECTOR).length).toBe(0);
     });
 
@@ -1360,11 +1360,11 @@ describe('Select', function() {
     searchable: "Searchable"
   }];
 
-  // 101 options.
+  // 601 options.
   var OPTIONS_LONG = (function () {
     var options = [];
 
-    for (var i = 1; i <= 101; ++i) {
+    for (var i = 1; i <= 601; ++i) {
       options.push({ value: '' + i, label: 'Optiony Option ' + i });
     }
 


### PR DESCRIPTION
Increasing tw-select large option size from 50 to 300. It caused problems with frontend-apps protractor tests. 
Thread: https://transferwise.slack.com/archives/CK8HAK6DA/p1560934456004000