### PR TITLE
fix: divs with .error-min or .error-max are visible no matter the error

### DIFF
--- a/src/forms/field/field.controller.js
+++ b/src/forms/field/field.controller.js
@@ -1,3 +1,7 @@
+const STRING_VALIDATION_TYPES = ['async', 'required', 'min', 'max', 'pattern', 'minlength', 'maxlength'];
+const NUMBER_VALIDATION_TYPES = ['async', 'required', 'min', 'max'];
+const BOOLEAN_VALIDATION_TYPES = ['async', 'required'];
+
 class FieldController {
   constructor(RequirementsService) {
     this.RequirementsService = RequirementsService;
@@ -64,6 +68,22 @@ class FieldController {
         controlType === 'tel') {
       return true;
     }
+    return false;
+  }
+
+  isValidationApplicable(validationType) {
+    if (this.field.type === 'string') {
+      return STRING_VALIDATION_TYPES.indexOf(validationType) !== -1;
+    }
+
+    if (this.field.type === 'number') {
+      return NUMBER_VALIDATION_TYPES.indexOf(validationType) !== -1;
+    }
+
+    if (this.field.type === 'boolean') {
+      return BOOLEAN_VALIDATION_TYPES.indexOf(validationType) !== -1;
+    }
+
     return false;
   }
 }

--- a/src/forms/field/field.html
+++ b/src/forms/field/field.html
@@ -41,7 +41,9 @@
     ng-class="{
       'alert-detach': $ctrl.isFeedbackDetached($ctrl.control)
     }">
-    <div ng-repeat="(validationType, validationMessage) in $ctrl.field.validationMessages track by $index"
+    <div
+      ng-repeat="(validationType, validationMessage) in $ctrl.field.validationMessages track by $index"
+      ng-if="$ctrl.isValidationApplicable(validationType)"
       class="error-{{ validationType | lowercase }}">
       {{validationMessage}}
     </div>

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -19,8 +19,8 @@ class FieldsetController {
       this.validationMessages = {
         required: 'Required',
         pattern: 'Incorrect format',
-        minimum: 'The value is too low',
-        maximum: 'The value is too high',
+        min: 'The value is too low',
+        max: 'The value is too high',
         minlength: 'The value is too short',
         maxlength: 'The value is too long'
       };

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -200,6 +200,44 @@ describe('Fieldset', function() {
       expect(sortCodeField.controller('twField').required).toBe(true);
       expect(ibanField.controller('twField').required).toBe(false);
     });
+
+    it('should only show applicable error messages', function() {
+      var sortCodeField = fields[0];
+      var ibanField = fields[1];
+
+      var errorNodesFor = function(element) {
+        return {
+          required: element.querySelector(".error-required"),
+          pattern: element.querySelector(".error-pattern"),
+          min: element.querySelector(".error-minimum"),
+          max: element.querySelector(".error-maximum"),
+          minLength: element.querySelector(".error-minlength"),
+          maxLength: element.querySelector(".error-maxlength")
+        };
+      };
+
+      sortCodeField.blur();
+      ibanField.blur();
+
+      var sortCodeErrors = errorNodesFor(sortCodeField);
+      var ibanErrors = errorNodesFor(ibanField);
+
+      expect(sortCodeErrors.required.innerText).toContain(
+        $scope.fields[0].validationMessages.required
+      );
+      expect(sortCodeErrors.pattern).toBeNull();
+      expect(sortCodeErrors.minLength).toBeNull();
+      expect(sortCodeErrors.maxLength).toBeNull();
+      expect(sortCodeErrors.min).toBeNull();
+      expect(sortCodeErrors.max).toBeNull();
+
+      expect(ibanErrors.required).toBeTruthy();
+      expect(ibanErrors.pattern).toBeTruthy();
+      expect(ibanErrors.minLength).toBeTruthy();
+      expect(ibanErrors.maxLength).toBeTruthy();
+      expect(ibanErrors.min).toBeNull();
+      expect(ibanErrors.max).toBeNull();
+    });
   });
 
   function getCompiledDirectiveElement() {


### PR DESCRIPTION
the bug has the effect that for a given field:
```
{
  key: 'ssn',
  name: 'Your US Social Security Number',
  width: 'lg',
  type: 'text',
  required: true,
  hidden: false,
  placeholder: '111-22-3333',
  refreshRequirementsOnChange: false,
  displayFormat: '***-**-****',
  minLength: 9,
  maxLength: 9
}
```

the default `validationMessages` are being applied to it which include the [deprecated??] `minimum` and `maximum` keys.

and so the DOM nodes with classes `.error-minimum` or `.error-maximum` were not being hidden from UI