### PR TITLE
fix(select): filter duplicates based on label and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.8.5
+## Filter duplicates based on label and value in tw-select
+
 # v3.8.4
 ## Increase the tw-select large option size from 50 to 300
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -134,23 +134,25 @@ class SelectController {
     }
 
     const filterStringLower =
-        this.filterString && escapeRegExp(this.filterString.toLowerCase());
+      this.filterString && escapeRegExp(this.filterString.toLowerCase());
 
-    const encounteredLabels = Object.create(null);
+    const encounteredLabelsAndValues = {};
 
     const filteredOptions = [];
     for (let i = 0; i < this.options.length; ++i) {
       const option = this.options[i];
 
-      const isDuplicate = encounteredLabels[option.label];
+      const isDuplicate =
+        encounteredLabelsAndValues[option.label] &&
+        angular.equals(encounteredLabelsAndValues[option.label], option.value);
 
-      const shouldAddOption = !isDuplicate && (
-        !filterStringLower || // empty filterstring means pass everything.
-        labelMatches(option, filterStringLower) ||
-        noteMatches(option, filterStringLower) ||
-        secondaryMatches(option, filterStringLower) ||
-        searchableMatches(option, filterStringLower)
-      );
+      const shouldAddOption =
+        !isDuplicate &&
+        (!filterStringLower || // empty filterstring means pass everything.
+          labelMatches(option, filterStringLower) ||
+          noteMatches(option, filterStringLower) ||
+          secondaryMatches(option, filterStringLower) ||
+          searchableMatches(option, filterStringLower));
 
       if (shouldAddOption) {
         // Too many options? Don't add anymore, indicate that there's more instead.
@@ -159,7 +161,7 @@ class SelectController {
           break;
         }
 
-        encounteredLabels[option.label] = true;
+        encounteredLabelsAndValues[option.label] = option.value;
         filteredOptions.push(option);
       }
     }

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -136,15 +136,25 @@ class SelectController {
     const filterStringLower =
       this.filterString && escapeRegExp(this.filterString.toLowerCase());
 
-    const encounteredLabelsAndValues = {};
+    const encounteredLabelsAndValues = Object.create(null);
 
     const filteredOptions = [];
     for (let i = 0; i < this.options.length; ++i) {
       const option = this.options[i];
 
-      const isDuplicate =
-        encounteredLabelsAndValues[option.label] &&
-        angular.equals(encounteredLabelsAndValues[option.label], option.value);
+      let isDuplicate = false;
+
+      const existingValuesForLabel = encounteredLabelsAndValues[option.label];
+      const hasExistingValues = angular.isArray(existingValuesForLabel);
+
+      if (hasExistingValues) {
+        for (let j = 0; j < existingValuesForLabel.length; j++) {
+          if (angular.equals(existingValuesForLabel[j], option.value)) {
+            isDuplicate = true;
+            break;
+          }
+        }
+      }
 
       const shouldAddOption =
         !isDuplicate &&
@@ -161,7 +171,12 @@ class SelectController {
           break;
         }
 
-        encounteredLabelsAndValues[option.label] = option.value;
+        if (hasExistingValues) {
+          existingValuesForLabel.push(option.value);
+        } else {
+          encounteredLabelsAndValues[option.label] = [option.value];
+        }
+
         filteredOptions.push(option);
       }
     }

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -1145,7 +1145,7 @@ describe('Select', function() {
     });
   });
 
-  describe('filter duplicates', function() {
+  describe('filter duplicates with same label and value', function() {
     var $filterInput;
     beforeEach(function () {
       $scope.options = [{
@@ -1177,6 +1177,42 @@ describe('Select', function() {
       var options = component.find(LIST_ITEMS_SELECTOR);
       expect(options.length).toBe(1);
       expect(optionText(options[0])).toBe('Cain');
+    });
+  });
+
+  describe('render options with same label but different value', function() {
+    var $filterInput;
+    beforeEach(function () {
+      $scope.options = [{
+        value: '0',
+        label: 'Abel'
+      },{
+        value: '1',
+        label: 'Cain'
+      },{
+        value: '2',
+        label: 'Cain'
+      }];
+      $scope.filter = 'Search';
+      var template = " \
+        <tw-select \
+          options='options' \
+          ng-model='ngModel' \
+          filter='{{filter}}'> \
+          <a href='' class='custom-action'> \
+              Custom action \
+          </a> \
+        </tw-select>";
+      component = getComponent($scope, template);
+      $filterInput = component.find(FILTER_INPUT_SELECTOR);
+    });
+
+    it('should show two results', function() {
+      $filterInput.val("ca").trigger('change');
+      var options = component.find(LIST_ITEMS_SELECTOR);
+      expect(options.length).toBe(2);
+      expect(optionText(options[0])).toBe('Cain');
+      expect(optionText(options[1])).toBe('Cain');
     });
   });
 

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -1149,11 +1149,11 @@ describe('Select', function() {
     var $filterInput;
     beforeEach(function () {
       $scope.options = [{
-        value: '0',
-        label: 'Abel'
-      },{
         value: '1',
         label: 'Cain'
+      },{
+        value: '0',
+        label: 'Abel'
       },{
         value: '1',
         label: 'Cain'
@@ -1184,11 +1184,11 @@ describe('Select', function() {
     var $filterInput;
     beforeEach(function () {
       $scope.options = [{
-        value: '0',
-        label: 'Abel'
-      },{
         value: '1',
         label: 'Cain'
+      },{
+        value: '0',
+        label: 'Abel'
       },{
         value: '2',
         label: 'Cain'


### PR DESCRIPTION
Comparing and eliminating duplicates in `twSelect` using only labels breaks most of the recipient dropdowns.

You can have several different recipients/bank account details using the same name - for example I can have 1000 recipients called `John Doe` but the current implementation would just allow me to render one in the available options.

This PR fixes that checking the values as well for the same label.