### PR TITLE
chore: use LTS version of Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/styleguide-components
   docker:
-    - image: circleci/node:10.6-browsers
+    - image: circleci/node:lts-browsers
 
 jobs:
   test:


### PR DESCRIPTION
Use LTS version of Node instead of 10.6 which has been released mid 2018.