### PR TITLE
fix(fieldset): use proper keys for matching CSS rule for hiding error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.9.1
+## Fix min and max validation error messages
+
 # v3.9.0
 ## Adds "empty" option to tw-card
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.8.5",
+  "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -19,8 +19,8 @@ class FieldsetController {
       this.validationMessages = {
         required: 'Required',
         pattern: 'Incorrect format',
-        minimum: 'The value is too low',
-        maximum: 'The value is too high',
+        min: 'The value is too low',
+        max: 'The value is too high',
         minlength: 'The value is too short',
         maxlength: 'The value is too long'
       };


### PR DESCRIPTION
<!--- Mandatory field -->
### Title
<!--- Provide a general summary of your changes -->
Fix unwanted `min` and `max` validation rules visibility.

![image](https://user-images.githubusercontent.com/11005750/61799929-5044f000-ae2c-11e9-953e-5e1f2bca9980.png)

<!--- Mandatory field -->
### Description
<!--- Describe your changes in detail -->

#### tl;dr

- `error-min` and `error-max` CSS rule should hide the `The value is too low` and `The value is too high`error messages
- These CSS classes are generated in the DOM by reading an object key's like `error-{{ validationType }}` (where `validationType` is the key of the object)
- That object had wrong keys: `minimum` instead of `min` and `maximum` instead of `max`
- CSS classes were not matched, thus error message has been visible beside the fact that validation passed for these rules.

#### Detailed description

For some reason when a field validation has happened the `min` and `max` validation rules have been triggered automatically, however most of the times the field had no configuration for those validation properties.

After an investigation I've manage to find out that the validation model is correct and the validators attached to the `$ngModel` instance are correctly implemented, so the error message was not displayed because the validation methods were triggered.

I found out that the default error messages are coming from `FieldsetController` and these default validation error messages are displayed driven by the right [combination of CSS classes](https://github.com/transferwise/bootstrap/blob/1bd8f1821846ab57ac0175b24eb0ece7af013b82/less/forms.less#L964-L999) defined in Bootstrap.

I found that the `The value is too low` and `The value is too high` error messages are displayed because they were not matching with their corresponding "hiding" CSS rule `error-min` and `error-max` because the class names in the DOM were `error-minimum` and `error-maximum`.

These class names are generated from the keys of the `$ctrl.validationMessages` object which gets initialised with these properties:

https://github.com/transferwise/styleguide-components/blob/99ebcae667e1ce8da237bdcd307d23eb987132fc/src/forms/fieldset/fieldset.controller.js#L19-L26

You can now see why those error messages were visible.


<!--- Mandatory field -->
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No feature or interface has changed
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality or interface to change)

<!--- Optional field -->
### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/11005750/61801316-d6623600-ae2e-11e9-93a4-9c7dcd7ef37f.png)
