### PR TITLE
fix(select): display all headers passed to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.9.3
+## Render all header option in select
+
 # v3.9.2
 ## Update dependencies, remove jshint.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -143,6 +143,12 @@ class SelectController {
     for (let i = 0; i < this.options.length; ++i) {
       const option = this.options[i];
 
+      if (option.header && !option.value && !option.label) {
+        filteredOptions.push(option);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
       let isDuplicate = false;
 
       const existingValuesForLabel = encounteredLabelsAndValues[option.label];

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -1217,8 +1217,6 @@ describe('Select', function() {
   });
 
   describe('when multiple headers are passed', function() {
-    var $filterInput;
-
     beforeEach(function () {
       $scope.options = [
         { header: 'First' },
@@ -1242,16 +1240,11 @@ describe('Select', function() {
           options='options' \
           ng-model='ngModel' \
           filter='{{filter}}'> \
-          <a href='' class='custom-action'> \
-              Custom action \
-          </a> \
         </tw-select>";
       component = getComponent($scope, template);
-      $filterInput = component.find(FILTER_INPUT_SELECTOR);
     });
 
     it('should show two header options', function() {
-      $filterInput.val("ca").trigger('change');
       var options = component.find('span[ng-if="option.header"]');
       expect(options.length).toBe(2);
       expect(optionText(options[0])).toBe('First');

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -1216,6 +1216,49 @@ describe('Select', function() {
     });
   });
 
+  describe('when multiple headers are passed', function() {
+    var $filterInput;
+
+    beforeEach(function () {
+      $scope.options = [
+        { header: 'First' },
+        {
+          value: '1',
+          label: 'Cain'
+        },
+        {
+          value: '0',
+          label: 'Abel'
+        },
+        { header: 'Second' },
+        {
+          value: '1',
+          label: 'Cain'
+        }
+      ];
+      $scope.filter = 'Search';
+      var template = " \
+        <tw-select \
+          options='options' \
+          ng-model='ngModel' \
+          filter='{{filter}}'> \
+          <a href='' class='custom-action'> \
+              Custom action \
+          </a> \
+        </tw-select>";
+      component = getComponent($scope, template);
+      $filterInput = component.find(FILTER_INPUT_SELECTOR);
+    });
+
+    it('should show two header options', function() {
+      $filterInput.val("ca").trigger('change');
+      var options = component.find('span[ng-if="option.header"]');
+      expect(options.length).toBe(2);
+      expect(optionText(options[0])).toBe('First');
+      expect(optionText(options[1])).toBe('Second');
+    });
+  });
+
   function getComponent($scope, template) {
     if (!template) {
       template = " \

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -1234,12 +1234,10 @@ describe('Select', function() {
           label: 'Cain'
         }
       ];
-      $scope.filter = 'Search';
       var template = " \
         <tw-select \
           options='options' \
-          ng-model='ngModel' \
-          filter='{{filter}}'> \
+          ng-model='ngModel'> \
         </tw-select>";
       component = getComponent($scope, template);
     });


### PR DESCRIPTION
Only the first header option was displayed due to a bug in the logic determining the filtered options.

The logic did not handle properly those option objects which have no label and value but only have `header` key.

This should now be fixed with this PR.