### PR TITLE
Ensure components include their dependent modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.10.3
+## Ensure components include their dependent modules
+Tests now only instantiate their own module, rather than the full library.
+Switch to using angular.mock.inject and angular.mock.module rather than globals.
+
 # v3.10.2
 ## Enable eslint operator-linebreak rule
 Fix violations.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/formatting/currency-format/currency-format.spec.js
+++ b/src/formatting/currency-format/currency-format.spec.js
@@ -10,9 +10,9 @@ describe('CurrencyFormat filter, ', function() {
       LocaleService;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.formatting.currency');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/formatting/date-format/date-format.filter.spec.js
+++ b/src/formatting/date-format/date-format.filter.spec.js
@@ -9,9 +9,9 @@ describe('DateFormat filter, ', function() {
       DateService;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.formatting.date');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       DateService = $injector.get('TwDateService');

--- a/src/formatting/date-format/index.js
+++ b/src/formatting/date-format/index.js
@@ -1,9 +1,12 @@
 import angular from 'angular';
 import DateFormat from './date-format.component';
 import DateFilter from './date-format.filter';
+import DateService from '../../services/date';
 
 export default angular
-  .module('tw.styleguide.formatting.date', [])
+  .module('tw.styleguide.formatting.date', [
+    DateService
+  ])
   .component('twDateFormat', DateFormat)
   .filter('twDateFormat', DateFilter)
   .name;

--- a/src/formatting/number-format/number-format.spec.js
+++ b/src/formatting/number-format/number-format.spec.js
@@ -10,9 +10,9 @@ describe('NumberFormat filter, ', function() {
       LocaleService;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.formatting.number');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/formatting/text-format/text-format.directive.spec.js
+++ b/src/formatting/text-format/text-format.directive.spec.js
@@ -9,9 +9,9 @@ describe('TextFormat directive, ', function() {
       input;
 
   beforeEach(function() {
-    module('tw.styleguide.formatting.text-format');
+    angular.mock.module('tw.styleguide.formatting.text-format');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/formatting/text-format/text-format.filter.spec.js
+++ b/src/formatting/text-format/text-format.filter.spec.js
@@ -9,10 +9,9 @@ describe('TextFormat filter, ', function() {
       input;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.styleguide.formatting.text-format');
+    angular.mock.module('tw.styleguide.formatting.text-format');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/amount-currency-select/amount-currency-select.spec.js
+++ b/src/forms/amount-currency-select/amount-currency-select.spec.js
@@ -15,9 +15,12 @@ describe('AmountCurrencySelect', function() {
   var SELECT_SELECTOR = 'select';
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.forms.amount-currency-select');
 
-    inject(function($injector) {
+    // Used in a transclusion test
+    angular.mock.module('tw.styleguide.loading.loader');
+
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/amount-currency-select/index.js
+++ b/src/forms/amount-currency-select/index.js
@@ -2,11 +2,12 @@ import angular from 'angular';
 import Select from '../select';
 import AmountCurrencySelect from './amount-currency-select.component.js';
 import CurrencyService from '../../services/currency';
-
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.amount-currency-select', [
     Select,
-    CurrencyService
+    CurrencyService,
+    Focusable
   ])
   .component('twAmountCurrencySelect', AmountCurrencySelect).name;

--- a/src/forms/checkbox/checkbox.spec.js
+++ b/src/forms/checkbox/checkbox.spec.js
@@ -15,12 +15,9 @@ describe('Checkbox', function() {
   var LABEL_SELECTOR = '.checkbox label';
 
   beforeEach(function() {
-    module('tw.styleguide.forms.checkbox');
-    module('tw.styleguide.forms.focusable');
-    module('tw.styleguide.validation');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.checkbox');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
     });

--- a/src/forms/checkbox/index.js
+++ b/src/forms/checkbox/index.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import Checkbox from './checkbox.component.js';
 import DomService from '../../services/dom';
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.checkbox', [
-    DomService
+    DomService,
+    Focusable
   ])
   .component('twCheckbox', Checkbox).name;

--- a/src/forms/currency-input/currency-input.spec.js
+++ b/src/forms/currency-input/currency-input.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-fdescribe('CurrencyInput', function() {
+describe('CurrencyInput', function() {
   var $compile,
     $rootScope,
     $scope,

--- a/src/forms/currency-input/currency-input.spec.js
+++ b/src/forms/currency-input/currency-input.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('CurrencyInput', function() {
+fdescribe('CurrencyInput', function() {
   var $compile,
     $rootScope,
     $scope,
@@ -14,9 +14,12 @@ describe('CurrencyInput', function() {
   var INPUT_SELECTOR = 'input';
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.forms.currency-input');
 
-    inject(function($injector) {
+    // Used in a transclusion test
+    angular.mock.module('tw.styleguide.loading.loader');
+
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
     });

--- a/src/forms/currency-input/index.js
+++ b/src/forms/currency-input/index.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import CurrencyInput from './currency-input.component.js';
 import CurrencyService from '../../services/currency';
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.currency-input', [
-    CurrencyService
+    CurrencyService,
+    Focusable
   ])
   .component('twCurrencyInput', CurrencyInput).name;

--- a/src/forms/date-lookup/date-lookup.spec.js
+++ b/src/forms/date-lookup/date-lookup.spec.js
@@ -8,11 +8,9 @@ describe('DateLookup, ', function() {
       TwDateService;
 
   beforeEach(function() {
-    module('tw.styleguide.forms.date-lookup');
-    module('tw.styleguide.services.date');
-    module('tw.styleguide.services.dom');
+    angular.mock.module('tw.styleguide.forms.date-lookup');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       TwDateService = $injector.get('TwDateService');

--- a/src/forms/date/date.spec.js
+++ b/src/forms/date/date.spec.js
@@ -7,10 +7,9 @@ describe('Date', function() {
     element;
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.date');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/date/index.js
+++ b/src/forms/date/index.js
@@ -1,9 +1,15 @@
 import angular from 'angular';
-import DateControl from './date.component.js';
+import DateControl from './date.component';
 import DateService from '../../services/date';
+import DateFormat from '../../formatting/date-format';
+import Select from '../select';
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.date', [
-    DateService
+    DateService,
+    DateFormat,
+    Select,
+    Focusable
   ])
   .component('twDate', DateControl).name;

--- a/src/forms/definition-list/definition-list.spec.js
+++ b/src/forms/definition-list/definition-list.spec.js
@@ -11,9 +11,9 @@ describe('Definition list', function() {
     definition;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.requirements.definition-list');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
     });

--- a/src/forms/definition-list/index.js
+++ b/src/forms/definition-list/index.js
@@ -2,9 +2,13 @@ import angular from 'angular';
 import DefinitionList from './definition-list.component.js';
 
 import Formatting from '../../formatting';
+import RequirementsService from '../../services/requirements';
+import DateService from '../../services/date';
 
 export default angular
   .module('tw.styleguide.requirements.definition-list', [
-    Formatting
+    Formatting,
+    RequirementsService,
+    DateService
   ])
   .component('twDefinitionList', DefinitionList).name;

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -9,9 +9,9 @@ describe('Field', function() {
       $timeout;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.forms.field');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/field/index.js
+++ b/src/forms/field/index.js
@@ -2,10 +2,12 @@ import angular from 'angular';
 import FormControl from '../form-control';
 import Field from './field.component';
 import RequirementsService from '../../services/requirements';
+import ControlValidation from '../../validation/control-validation';
 
 export default angular
   .module('tw.styleguide.forms.field', [
     FormControl,
-    RequirementsService
+    RequirementsService,
+    ControlValidation
   ])
   .component('twField', Field).name;

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -8,9 +8,9 @@ describe('Fieldset', function() {
       $timeout;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.forms.fieldset');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/fieldset/index.js
+++ b/src/forms/fieldset/index.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
+import Fieldset from './fieldset.component';
 import Field from '../field';
-import Fieldset from './fieldset.component.js';
 import RequirementsService from '../../services/requirements';
 
 export default angular

--- a/src/forms/focusable/focusable.spec.js
+++ b/src/forms/focusable/focusable.spec.js
@@ -10,10 +10,9 @@ describe('Focusable', function() {
   var FOCUSABLE_SELECTOR = '[tw-focusable]';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.focusable');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
     });

--- a/src/forms/form-control/form-control.spec.js
+++ b/src/forms/form-control/form-control.spec.js
@@ -10,10 +10,9 @@ describe('FormControl', function() {
     input;
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.form-control');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $scope = $rootScope.$new();
       $compile = $injector.get('$compile');

--- a/src/forms/radio/index.js
+++ b/src/forms/radio/index.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import Radio from './radio.component.js';
 import DomService from '../../services/dom';
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.radio', [
-    DomService
+    DomService,
+    Focusable
   ])
   .component('twRadio', Radio).name;

--- a/src/forms/radio/radio.spec.js
+++ b/src/forms/radio/radio.spec.js
@@ -21,11 +21,9 @@ describe('Radio', function() {
   var LABEL_SELECTOR = '.radio label';
 
   beforeEach(function() {
-    module('tw.styleguide.forms')
-    module('tw.styleguide.validation')
-    module('tw.styleguide.services')
+    angular.mock.module('tw.styleguide.forms.radio');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
     });

--- a/src/forms/requirements-form/requirements-form.spec.js
+++ b/src/forms/requirements-form/requirements-form.spec.js
@@ -11,9 +11,7 @@ describe('RequirementsForm', function() {
     RequirementsService;
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.navigation');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.requirements-form');
 
     Fieldset = getMockComponent('twFieldset');
     Tabs = getMockComponent('twTabs');
@@ -21,7 +19,7 @@ describe('RequirementsForm', function() {
     angular.mock.module('tw.styleguide.forms.fieldset', Fieldset);
     angular.mock.module('tw.styleguide.navigation.tabs', Tabs);
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/select/index.js
+++ b/src/forms/select/index.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import Select from './select.component.js';
 import DomService from '../../services/dom';
+import Focusable from '../focusable';
 
 export default angular
   .module('tw.styleguide.forms.select', [
-    DomService
+    DomService,
+    Focusable
   ])
   .component('twSelect', Select).name;

--- a/src/forms/select/select-filter.spec.js
+++ b/src/forms/select/select-filter.spec.js
@@ -11,10 +11,9 @@ describe('Select', function() {
   var FILTER_INPUT_SELECTOR = '.tw-select-filter';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.select');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/select/select-option-extras.spec.js
+++ b/src/forms/select/select-option-extras.spec.js
@@ -25,10 +25,9 @@ describe('Select', function() {
   var OPTION_DISABLED_SELECTOR = '.dropdown-menu .disabled';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.select');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/select/select.spec.js
+++ b/src/forms/select/select.spec.js
@@ -14,10 +14,9 @@ describe('Select', function() {
   var OPTION_LOAD_MORE_SELECTOR = '.dropdown-menu .tw-select-load-more';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
-    module('tw.styleguide.services');
+    angular.mock.module('tw.styleguide.forms.select');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/submit/index.js
+++ b/src/forms/submit/index.js
@@ -1,9 +1,11 @@
 import angular from 'angular';
 import Submit from './submit.component.js';
 import Process from '../../loading/process';
+import DomService from '../../services/dom';
 
 export default angular
   .module('tw.styleguide.forms.submit', [
-    Process
+    Process,
+    DomService
   ])
   .component('twSubmit', Submit).name;

--- a/src/forms/submit/submit.spec.js
+++ b/src/forms/submit/submit.spec.js
@@ -7,9 +7,9 @@ describe('Given a submit button component', function() {
   var BUTTON_SELECTOR = 'button';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
+    angular.mock.module('tw.styleguide.forms.submit');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/telephone/telephone.spec.js
+++ b/src/forms/telephone/telephone.spec.js
@@ -8,9 +8,9 @@ describe('Given a telephone number component', function() {
   var NUMBER_SELECTOR = 'input[name=phoneNumber]';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
+    angular.mock.module('tw.styleguide.forms.telephone');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $timeout = $injector.get('$timeout');

--- a/src/forms/upload-droppable/upload-droppable.directive.spec.js
+++ b/src/forms/upload-droppable/upload-droppable.directive.spec.js
@@ -12,9 +12,9 @@ describe('Directive: TwUploadDroppable', function() {
   var FILTER_INPUT_SELECTOR = '.tw-select-filter';
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
+    angular.mock.module('tw.styleguide.forms.upload-droppable');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -21,9 +21,9 @@ describe('given an upload component', function() {
    "Av7czFnnAAAAAElFTkSuQmCC";
 
   beforeEach(function() {
-    module('tw.styleguide.forms');
+    angular.mock.module('tw.styleguide.forms.upload');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();
@@ -334,5 +334,5 @@ describe('given an upload component', function() {
     $scope.$digest();
     return compiledElement[0];
   }
-  
+
 });

--- a/src/help/pop-over/pop-over.directive.spec.js
+++ b/src/help/pop-over/pop-over.directive.spec.js
@@ -8,9 +8,9 @@ describe('Popover directive', function() {
       popover;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.help.popover');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $window = $injector.get('$window');

--- a/src/json-schema/all-of-schema/spec.js
+++ b/src/json-schema/all-of-schema/spec.js
@@ -7,13 +7,12 @@ describe('Given a component from rendering allOf schemas', function() {
     genericSchema;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.all-of');
 
     genericSchema = getMockComponent('genericSchema');
     angular.mock.module('tw.json-schema.generic', genericSchema);
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     });

--- a/src/json-schema/array-schema/spec.js
+++ b/src/json-schema/array-schema/spec.js
@@ -7,12 +7,12 @@ describe('Given a component for arrays of schemas', function() {
     genericSchema;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.array');
 
     genericSchema = getMockComponent('genericSchema');
     angular.mock.module('tw.json-schema.generic', genericSchema);
-    inject(function($injector) {
+
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     });

--- a/src/json-schema/basic-type-schema/index.js
+++ b/src/json-schema/basic-type-schema/index.js
@@ -1,6 +1,9 @@
 import angular from 'angular';
 import Component from './component';
+import Field from '../../forms/field';
 
 export default angular
-  .module('tw.json-schema.basic-type', [])
+  .module('tw.json-schema.basic-type', [
+    Field
+  ])
   .component('basicTypeSchema', Component).name;

--- a/src/json-schema/basic-type-schema/spec.js
+++ b/src/json-schema/basic-type-schema/spec.js
@@ -7,13 +7,12 @@ describe('Given a component for rendering basic type schemas', function() {
     twField;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.basic-type');
 
     twField = getMockComponent('twField');
     angular.mock.module('tw.styleguide.forms.field', twField);
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     });

--- a/src/json-schema/generic-schema/index.js
+++ b/src/json-schema/generic-schema/index.js
@@ -1,6 +1,18 @@
 import angular from 'angular';
 import Component from './component';
 
+import BasicTypeSchema from '../basic-type-schema';
+import ObjectSchema from '../object-schema';
+import ArraySchema from '../array-schema';
+import AllOfSchema from '../all-of-schema';
+import OneOfSchema from '../one-of-schema';
+
 export default angular
-  .module('tw.json-schema.generic', [])
+  .module('tw.json-schema.generic', [
+    BasicTypeSchema,
+    ObjectSchema,
+    ArraySchema,
+    AllOfSchema,
+    OneOfSchema
+  ])
   .component('genericSchema', Component).name;

--- a/src/json-schema/generic-schema/spec.js
+++ b/src/json-schema/generic-schema/spec.js
@@ -12,8 +12,7 @@ describe('Given a component for rendering any generic schema', function() {
     childComponent;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.generic');
 
     oneOfSchema = getMockComponent('oneOfSchema');
     allOfSchema = getMockComponent('allOfSchema');
@@ -27,7 +26,7 @@ describe('Given a component for rendering any generic schema', function() {
     angular.mock.module('tw.json-schema.array', arraySchema);
     angular.mock.module('tw.json-schema.basic-type', basicTypeSchema);
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     })

--- a/src/json-schema/object-schema/spec.js
+++ b/src/json-schema/object-schema/spec.js
@@ -7,13 +7,12 @@ describe('Given a component for rendering object schemas', function() {
     genericSchema;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.object');
 
     genericSchema = getMockComponent('genericSchema');
     angular.mock.module('tw.json-schema.generic', genericSchema);
-    
-    inject(function($injector) {
+
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     });

--- a/src/json-schema/one-of-schema/index.js
+++ b/src/json-schema/one-of-schema/index.js
@@ -1,6 +1,9 @@
 import angular from 'angular';
 import Component from './component';
+import Radio from '../../forms/radio';
 
 export default angular
-  .module('tw.json-schema.one-of', [])
+  .module('tw.json-schema.one-of', [
+    Radio
+  ])
   .component('oneOfSchema', Component).name;

--- a/src/json-schema/one-of-schema/spec.js
+++ b/src/json-schema/one-of-schema/spec.js
@@ -7,13 +7,12 @@ describe('Given an oneOfSchema component', function() {
     genericSchema;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.one-of');
 
     genericSchema = getMockComponent('genericSchema');
     angular.mock.module('tw.json-schema.generic', genericSchema);
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $compile = $injector.get('$compile');
       $scope = $injector.get('$rootScope').$new();
     });

--- a/src/json-schema/validation/rule-validators/spec.js
+++ b/src/json-schema/validation/rule-validators/spec.js
@@ -4,10 +4,9 @@ describe('Given a library for validating json schema rules', function() {
   var schema, ruleValidators;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.validation');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var SchemaValidation = $injector.get('SchemaValidation');
       ruleValidators = SchemaValidation.ruleValidators;
     });

--- a/src/json-schema/validation/schema-validators/spec.js
+++ b/src/json-schema/validation/schema-validators/spec.js
@@ -4,10 +4,9 @@ describe('Given a library for validating json schema models', function() {
   var schema, isValidSchema;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.validation');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var SchemaValidation = $injector.get('SchemaValidation');
       isValidSchema = SchemaValidation.isValidSchema;
     });

--- a/src/json-schema/validation/type-validators/spec.js
+++ b/src/json-schema/validation/type-validators/spec.js
@@ -4,10 +4,9 @@ describe('Given a library for validating data types', function() {
   var schema, typeValidators;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.validation');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var SchemaValidation = $injector.get('SchemaValidation');
       typeValidators = SchemaValidation.typeValidators;
     });

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -4,10 +4,9 @@ describe('Given a library for returning the valid parts of a model based on a sc
   var result, schema, getValidModelParts;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.validation');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var SchemaValidation = $injector.get('SchemaValidation');
       getValidModelParts = SchemaValidation.getValidModelParts;
     });

--- a/src/json-schema/validation/validation-failures/spec.js
+++ b/src/json-schema/validation/validation-failures/spec.js
@@ -4,10 +4,9 @@ describe('Given a library for identifying validation failures', function() {
   var schema, getValidationFailures;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
-    module('tw.json-schema');
+    angular.mock.module('tw.json-schema.validation');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       var SchemaValidation = $injector.get('SchemaValidation');
       getValidationFailures = SchemaValidation.getValidationFailures;
     })

--- a/src/layout/cards/cards.spec.js
+++ b/src/layout/cards/cards.spec.js
@@ -7,9 +7,9 @@ describe('Directive: TwCards', function() {
     directiveElement;
 
   beforeEach(function() {
-    module('tw.styleguide.layout');
+    angular.mock.module('tw.styleguide.layout.cards');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
       $scope = $rootScope.$new();

--- a/src/services/date/date.spec.js
+++ b/src/services/date/date.spec.js
@@ -5,9 +5,9 @@ describe('TwDateService test', function() {
   var dateFormats = ['narrow', 'short', 'long', null];
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.services.date');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       service = $injector.get('TwDateService');
     });
   });

--- a/src/services/dom/dom.spec.js
+++ b/src/services/dom/dom.spec.js
@@ -12,9 +12,9 @@ describe('DomService', function() {
     $compile;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.services.dom');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       dom = $injector.get('TwDomService');
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');

--- a/src/services/locale/locale.spec.js
+++ b/src/services/locale/locale.spec.js
@@ -4,9 +4,9 @@ describe('TwDateService test', function() {
   var LocaleService;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.services.locale');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       LocaleService = $injector.get('TwLocaleService');
     });
   });

--- a/src/services/requirements/requirements.spec.js
+++ b/src/services/requirements/requirements.spec.js
@@ -4,9 +4,9 @@ describe('Requirements Service', function() {
   var service;
 
   beforeEach(function() {
-    module('tw.styleguide-components');
+    angular.mock.module('tw.styleguide.services.requirements');
 
-    inject(function($injector) {
+    angular.mock.inject(function($injector) {
       service = $injector.get('TwRequirementsService');
     });
   });


### PR DESCRIPTION
Tests only instantiate their own module, rather than full library.
Switch to using angular.mock.inject and angular.mock.module rather than
globals.