### PR TITLE
Camera upload component minor css fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.12.1
+## Fix css style problem with buttons in camera upload component
+Fixed line-height attribute for cancel and confirm button in camera upload component
+
 # v3.12.0
 ## JSON schema forms now default to the first 'oneOf' schema that validates
 This is useful when editing existing data as we select a sensible schema.  Also

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/camera-capture/camera-capture.less
+++ b/src/forms/upload/camera-capture/camera-capture.less
@@ -39,7 +39,7 @@
   padding: 4px;
   margin-bottom: 0;
   font-size: 52px;
-  line-height: 24px;
+  line-height: 1;
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;


### PR DESCRIPTION
We have an agreement with Steve to keep css for this component here for now while we are iterating on it. 

Current
<img width="337" alt="Screenshot 2019-10-01 at 17 34 49" src="https://user-images.githubusercontent.com/47745211/65951071-dfe0cd80-e471-11e9-9014-33d3b11c9a1d.png">

Fixed
<img width="359" alt="Screenshot 2019-10-01 at 17 32 08" src="https://user-images.githubusercontent.com/47745211/65951078-e4a58180-e471-11e9-9e77-3738429b2b0c.png">
