### PR TITLE
fix: check if argument is an array before calling forEach on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.12.3
+## Select undefined options fix
+Check if the available options passed to the `twSelect` component is an iterable array
+
 # v3.12.2
 ## Camera upload component bugfix
 Convert camera direction component input to lowercase

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -428,6 +428,14 @@ function selectOption($ngModel, $ctrl, option) {
 }
 
 function findSelected(options, selected) {
+  // There can be scenarios when the `filteredOptions` are loaded asynchronously
+  // so this method may be called with an undefined as `options` argument, so
+  // we should check if that passed argument is really an array before calling
+  // `.forEach` on it
+  if (!angular.isArray(options)) {
+    return undefined;
+  }
+
   // Prefer forEach over find for browser support
   let selectedOption;
   options.forEach((option) => {


### PR DESCRIPTION
This PR fixes the scenario when the `filteredOptions` is undefined in `twSelect` resulting in a `TypeError`.

![image](https://user-images.githubusercontent.com/11005750/66384937-e61a0100-e9bf-11e9-98c0-6289011e40e5.png)
