### PR TITLE
Bump angular to 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3.12.4
+## Bump angular to 1.5.10
+The components use features introduced in 1.5.10, so the library should enforce that
+
 # v3.12.3
 ## Select undefined options fix
 Check if the available options passed to the `twSelect` component is an iterable array

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
   },
   "homepage": "https://github.com/transferwise/styleguide-components",
   "dependencies": {
-    "angular": "~1.5.0",
+    "angular": "~1.5.10",
     "jquery": "^3.4.1",
     "screenfull": "^4.2.0"
   },
   "devDependencies": {
     "@uirouter/angularjs": "^1.0.22",
-    "angular-mocks": "~1.5.0",
+    "angular-mocks": "~1.5.10",
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.12.3",
+  "version": "3.12.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Context:
`1.5.10` introduces the `ng-switch-when-separator` directive to be used with `ng-switch-when`. This functionality is used by `twFormControl` and `twDefinitionList`. Since we rely on the features of a specific version of angular, makes sense to enforce it more.

Related PR: https://github.com/transferwise/send-flow/pull/75
