### PR TITLE
AT-901 Temporarily remove httpOptions funcationality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v3.13.1
+# v4.0.0
 ## Temporarily remove async upload with tw-upload
 Until a robust solution is found to accept the correct url.
 We temporarily stop async upload, because it fails and stops a user from submitting the form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.13.1
+## Temporarily remove async upload with tw-upload
+Until a robust solution is found to accept the correct url.
+We temporarily stop async upload, because it fails and stops a user from submitting the form.
+
 # v3.13.0
 ## Feature enhancements for camera upload component
 Added camera overlay

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.13.1",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.13.1",
+  "version": "4.0.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -120,7 +120,8 @@ class UploadController {
      * NOTE: We temporarily want to ignore httpOptions until a full solution is implemented
      * Currently httpOptions.url is a relative path, but needs to know its baseUrl
      * As this call will return a 404, stopping a user from continuing the flow.
-     */
+    */
+
     // if (this.httpOptions) {
     //   // Post file now
     //   this.$q
@@ -131,12 +132,11 @@ class UploadController {
     //     .then(response => asyncSuccess(response[0], response[1], this))
     //     .catch(error => asyncFailure(error, this));
     // } else {
-      // Post on form submit
-      this.asyncFileRead(file)
-        .then(response => asyncSuccess(null, response, this))
-        .catch(error => asyncFailure(error, this));
-    //}
-
+    // Post on form submit
+    this.asyncFileRead(file)
+      .then(response => asyncSuccess(null, response, this))
+      .catch(error => asyncFailure(error, this));
+    // }
   }
 
   onDragEnter() {

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -116,21 +116,27 @@ class UploadController {
     }
     */
 
-    if (this.httpOptions) {
-      // Post file now
-      this.$q
-        .all([
-          this.asyncFileSave(file),
-          this.asyncFileRead(file)
-        ])
-        .then(response => asyncSuccess(response[0], response[1], this))
-        .catch(error => asyncFailure(error, this));
-    } else {
+    /*
+     * NOTE: We temporarily want to ignore httpOptions until a full solution is implemented
+     * Currently httpOptions.url is a relative path, but needs to know its baseUrl
+     * As this call will return a 404, stopping a user from continuing the flow.
+     */
+    // if (this.httpOptions) {
+    //   // Post file now
+    //   this.$q
+    //     .all([
+    //       this.asyncFileSave(file),
+    //       this.asyncFileRead(file)
+    //     ])
+    //     .then(response => asyncSuccess(response[0], response[1], this))
+    //     .catch(error => asyncFailure(error, this));
+    // } else {
       // Post on form submit
       this.asyncFileRead(file)
         .then(response => asyncSuccess(null, response, this))
         .catch(error => asyncFailure(error, this));
-    }
+    //}
+
   }
 
   onDragEnter() {

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -139,130 +139,136 @@ describe('given an upload component', function() {
     });
   });
 
-  describe('when a file is dropped and we have http-options', function() {
-    var deferred, mockFile, droppable;
+  /*
+   * NOTE: We temporarily want to ignore httpOptions until a full solution is implemented
+   * Currently httpOptions.url is a relative path, but needs to know its baseUrl
+   * As this call will return a 404, stopping a user from continuing the flow.=
+   */
 
-    beforeEach(function() {
-      var template = " \
-        <tw-upload \
-          name='myFile' \
-          ng-model='ngModel' \
-          on-success='onSuccess' \
-          on-failure='onFailure' \
-          processing-text='processing' \
-          success-text='success'\
-          failure-text='failure' \
-          http-options='httpOptions'> \
-        </tw-upload>";
+  // describe('when a file is dropped and we have http-options', function() {
+  //   var deferred, mockFile, droppable;
 
-      $scope.httpOptions = {
-        idProperty: 'id',
-        url: 'https://www.google.com',
-        method: 'POST'
-      };
+  //   beforeEach(function() {
+  //     var template = " \
+  //       <tw-upload \
+  //         name='myFile' \
+  //         ng-model='ngModel' \
+  //         on-success='onSuccess' \
+  //         on-failure='onFailure' \
+  //         processing-text='processing' \
+  //         success-text='success'\
+  //         failure-text='failure' \
+  //         http-options='httpOptions'> \
+  //       </tw-upload>";
 
-      $scope.ngModel = null;
-      $scope.onSuccess = jasmine.createSpy('onSuccess');
-      $scope.onFailure = jasmine.createSpy('onFailure');
+  //     $scope.httpOptions = {
+  //       idProperty: 'id',
+  //       url: 'https://www.google.com',
+  //       method: 'POST'
+  //     };
 
-      deferred = $q.defer();
-      spyOn(AsyncFileSaver, 'save').and.returnValue(deferred.promise);
-      spyOn(AsyncFileReader, 'read').and.returnValue($q.when(base64url));
+  //     $scope.ngModel = null;
+  //     $scope.onSuccess = jasmine.createSpy('onSuccess');
+  //     $scope.onFailure = jasmine.createSpy('onFailure');
 
-      directiveElement = getCompiledDirectiveElement($scope, template);
+  //     deferred = $q.defer();
+  //     spyOn(AsyncFileSaver, 'save').and.returnValue(deferred.promise);
+  //     spyOn(AsyncFileReader, 'read').and.returnValue($q.when(base64url));
 
-      mockFile = { size: 2 };
+  //     directiveElement = getCompiledDirectiveElement($scope, template);
 
-      var fakeDropEvent = new CustomEvent('drop');
-      fakeDropEvent.dataTransfer = { files : [ mockFile ] };
-      directiveElement.dispatchEvent(fakeDropEvent);
+  //     mockFile = { size: 2 };
 
-      droppable = directiveElement.querySelector('.droppable');
-    });
+  //     var fakeDropEvent = new CustomEvent('drop');
+  //     fakeDropEvent.dataTransfer = { files : [ mockFile ] };
+  //     directiveElement.dispatchEvent(fakeDropEvent);
 
-    it('should send the file to the asyncFileSaver', function() {
-      expect(AsyncFileSaver.save).toHaveBeenCalledWith(
-        'myFile', mockFile, $scope.httpOptions
-      );
-    });
+  //     droppable = directiveElement.querySelector('.droppable');
+  //   });
 
-    it('should show the processing screen', function() {
-      expect(droppable.classList).toContain('droppable-processing');
-    });
+  //   it('should send the file to the asyncFileSaver', function() {
+  //     expect(AsyncFileSaver.save).toHaveBeenCalledWith(
+  //       'myFile', mockFile, $scope.httpOptions
+  //     );
+  //   });
 
-    describe('when the timer has elapsed, but the API has not responded', function() {
-      beforeEach(function() {
-        $timeout.flush(4100);
-      });
+  //   it('should show the processing screen', function() {
+  //     expect(droppable.classList).toContain('droppable-processing');
+  //   });
 
-      it('should continue to show the processing screen', function() {
-        expect(droppable.classList).toContain('droppable-processing');
-      });
+  //   describe('when the timer has elapsed, but the API has not responded', function() {
+  //     beforeEach(function() {
+  //       $timeout.flush(4100);
+  //     });
 
-      it('should not call the onSuccess message', function() {
-        expect($scope.onSuccess).not.toHaveBeenCalled();
-      });
-    });
+  //     it('should continue to show the processing screen', function() {
+  //       expect(droppable.classList).toContain('droppable-processing');
+  //     });
 
-    describe('when the timer has elapsed and the request was resolved', function() {
-      beforeEach(function() {
-        var asyncResponse = { data: { id: 1234 } };
-        deferred.resolve(asyncResponse);
-        $timeout.flush(4100);
-      });
+  //     it('should not call the onSuccess message', function() {
+  //       expect($scope.onSuccess).not.toHaveBeenCalled();
+  //     });
+  //   });
 
-      it('should not show the processing screen', function() {
-        expect(droppable.classList).not.toContain('droppable-processing');
-      });
+  //   describe('when the timer has elapsed and the request was resolved', function() {
+  //     beforeEach(function() {
+  //       var asyncResponse = { data: { id: 1234 } };
+  //       deferred.resolve(asyncResponse);
+  //       $timeout.flush(4100);
+  //     });
 
-      it('should show the complete screen', function() {
-        expect(droppable.classList).toContain('droppable-complete');
-      });
+  //     it('should not show the processing screen', function() {
+  //       expect(droppable.classList).not.toContain('droppable-processing');
+  //     });
 
-      it('should show the success message', function() {
-        expect(directiveElement.querySelector('.upload-success-message')).toBeTruthy();
-      });
+  //     it('should show the complete screen', function() {
+  //       expect(droppable.classList).toContain('droppable-complete');
+  //     });
 
-      it('should extract the id from the response and bind to the model', function() {
-        expect($scope.ngModel).toBe(1234);
-      });
+  //     it('should show the success message', function() {
+  //       expect(directiveElement.querySelector('.upload-success-message')).toBeTruthy();
+  //     });
 
-      it('should call the onSuccess handler', function() {
-        expect($scope.onSuccess).toHaveBeenCalled();
-      });
-    });
+  //     it('should extract the id from the response and bind to the model', function() {
+  //       expect($scope.ngModel).toBe(1234);
+  //     });
 
-    describe('when the timer has elapsed and the request was rejected', function() {
-      beforeEach(function() {
-        deferred.reject({});
-        $timeout.flush(4100);
-      });
+  //     it('should call the onSuccess handler', function() {
+  //       expect($scope.onSuccess).toHaveBeenCalled();
+  //     });
+  //   });
 
-      it('should not show the processing screen', function() {
-        expect(droppable.classList).not.toContain('droppable-processing');
-      });
+  //   describe('when the timer has elapsed and the request was rejected', function() {
+  //     beforeEach(function() {
+  //       deferred.reject({});
+  //       $timeout.flush(4100);
+  //     });
 
-      it('should show the complete screen', function() {
-        expect(droppable.classList).toContain('droppable-complete');
-      });
+  //     it('should not show the processing screen', function() {
+  //       expect(droppable.classList).not.toContain('droppable-processing');
+  //     });
 
-      it('should show the failure message', function() {
-        expect(directiveElement.querySelector('.upload-failure-message')).toBeTruthy();
-      });
+  //     it('should show the complete screen', function() {
+  //       expect(droppable.classList).toContain('droppable-complete');
+  //     });
 
-      it('should not bind anything to the model', function() {
-        expect($scope.ngModel).toBe(null);
-      });
+  //     it('should show the failure message', function() {
+  //       expect(directiveElement.querySelector('.upload-failure-message')).toBeTruthy();
+  //     });
 
-      it('should not call the onSuccess handler', function() {
-        expect($scope.onSuccess).not.toHaveBeenCalled();
-      });
+  //     it('should not bind anything to the model', function() {
+  //       expect($scope.ngModel).toBe(null);
+  //     });
 
-      it('should call the onFailure handler', function() {
-        expect($scope.onFailure).toHaveBeenCalled();
-      });
-    });
-  });
+  //     it('should not call the onSuccess handler', function() {
+  //       expect($scope.onSuccess).not.toHaveBeenCalled();
+  //     });
+
+  //     it('should call the onFailure handler', function() {
+  //       expect($scope.onFailure).toHaveBeenCalled();
+  //     });
+  //   });
+  // });
 
   describe('when a transcluded success screen is supplied', function() {
     beforeEach(function() {


### PR DESCRIPTION
Temporarily disable, via comments, functionality attached to the httpOptions binding used in tw-upload. This functionality shouldn't be used anywhere in production yet, however when used, it causes issues regarding base url and blocks a user from continuing to submit.

Until an appropriate solution is found, we will have it commented out, not block work on backend and other clients.