### PR TITLE
AT-932 add optional upload text

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- ☝️ make the title meaningful -->
+
+## Context
+<!-- why this change is made -->
+
+## Changes
+<!-- what this PR does -->
+
+## Considerations
+<!-- additional info for reviewing, discussion topics -->
+
+## Original Pull Request (for version bumps)
+<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->
+
+## Screenshots/GIFs
+<!-- required for all visual changes -->
+
+### Before
+
+<!-- screenshot before change -->
+
+### After
+
+<!-- screenshot after change -->
+
+## Checklist
+
+- [ ] All changes are covered by tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.2.0
+## New upload option
+Fix bug where uploadOptions was not propagated correctly and add uploadingText to have single state processing copy as an option over processing -> success/failure copy.
+
 # v4.1.0
 ## New Async Task Config service
 New service to enhance and extend async functionality (persistAsync/validationAsync).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/field/field.html
+++ b/src/forms/field/field.html
@@ -19,7 +19,7 @@
     upload-icon="{{ $ctrl.field.icon }}"
     upload-too-large-message="{{ $ctrl.field.tooLargeMessage }}"
     options="$ctrl.field.values"
-    upload-options="$ctrl.field.uploadOptions"
+    upload-options="$ctrl.uploadOptions"
     ng-model="$ctrl.model"
     ng-focus="$ctrl.onFocus()"
     ng-blur="$ctrl.onBlur()"

--- a/src/forms/fieldset/fieldset.html
+++ b/src/forms/fieldset/fieldset.html
@@ -28,7 +28,7 @@
         on-change="$ctrl.fieldChange(value, key, field)"
         on-focus="$ctrl.fieldFocus(key, field)"
         on-blur="$ctrl.fieldBlur(key, field)"
-        class="btn-block"> <!-- Remove btn-block after boostrap update -->
+        >
       </tw-field>
 
       <!-- When we encouter an object property, use fieldset recusively -->
@@ -49,8 +49,7 @@
         on-field-change="$ctrl.fieldChange(value, key, field)"
         on-field-focus="$ctrl.fieldFocus(key, field)"
         on-field-blur="$ctrl.fieldBlur(key, field)"
-
-        class="btn-block"> <!-- Remove btn-block after boostrap update -->
+        >
       </tw-fieldset>
     </div>
   </div>

--- a/src/forms/form-control/form-control.html
+++ b/src/forms/form-control/form-control.html
@@ -64,6 +64,7 @@
       complete-text="{{$ctrl.label}}"
       button-text="{{$ctrl.uploadOptions.buttonText}}"
       cancel-text="{{$ctrl.uploadOptions.cancelText}}"
+      uploading-text="{{$ctrl.uploadOptions.uploadingText}}"
       too-large-message="{{$ctrl.uploadTooLargeMessage}}"
       max-size="$ctrl.ngMax"
       ng-model="$ctrl.internalModel"

--- a/src/forms/upload/upload.component.js
+++ b/src/forms/upload/upload.component.js
@@ -18,6 +18,7 @@ const Upload = {
     instructions: '@', // DEPRECATED for placeholder
     buttonText: '@',
     cancelText: '@', // Text instructing to go back to re-upload after upload is done
+    uploadingText: '@', // Single state text during uploading instead of processing/success/failure
     processingText: '@', // Text shown while uploading
     successText: '@', // Text after upload is successful, shown quite briefly before preview
     failureText: '@',

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -60,7 +60,7 @@
         <span ng-if="$ctrl.isSuccess && $ctrl.successText" class="upload-success-message">{{$ctrl.successText}}</span>
         <span ng-if="$ctrl.isError && $ctrl.failureText" class="upload-failure-message">{{$ctrl.failureText}}</span>
       </h4>
-      <tw-process size="sm" state="$ctrl.processingState" class="process"
+      <tw-process size="sm" state="$ctrl.processingState"
         ng-if="($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError)"></tw-process>
       <h4 ng-if="$ctrl.uploadingText" class="p-t-3">
         <span class="upload-processing-message">{{$ctrl.uploadingText}}</span>

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -63,7 +63,7 @@
       <tw-process size="sm" state="$ctrl.processingState"
         ng-if="($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError)"></tw-process>
       <h4 ng-if="$ctrl.uploadingText" class="p-t-3">
-        <span class="upload-processing-message">{{$ctrl.uploadingText}}</span>
+        <span class="uploading-message">{{$ctrl.uploadingText}}</span>
       </h4>
     </div>
   </div>

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -55,13 +55,16 @@
   <div class="droppable-processing-card droppable-card"
     aria-hidden="{{$ctrl.isDone}}">
     <div class="droppable-card-content">
-      <h4 class="m-b-2">
+      <h4 class="m-b-2" ng-if="!$ctrl.uploadingText">
         <span ng-if="$ctrl.isProcessing && $ctrl.processingText" class="upload-processing-message">{{$ctrl.processingText}}</span>
         <span ng-if="$ctrl.isSuccess && $ctrl.successText" class="upload-success-message">{{$ctrl.successText}}</span>
         <span ng-if="$ctrl.isError && $ctrl.failureText" class="upload-failure-message">{{$ctrl.failureText}}</span>
       </h4>
-      <tw-process size="sm" state="$ctrl.processingState"
+      <tw-process size="sm" state="$ctrl.processingState" class="process"
         ng-if="($ctrl.isProcessing || $ctrl.isSuccess || $ctrl.isError)"></tw-process>
+      <h4 ng-if="$ctrl.uploadingText" class="p-t-3">
+        <span class="upload-processing-message">{{$ctrl.uploadingText}}</span>
+      </h4>
     </div>
   </div>
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
To be able to add copy to show during the processing stage on the upload component. Currently it is set up to accept multiple states (processing/success/failure), we want it to also be able to accept a constant state, because the success and failure screens follow.

`uploadOptions` was being propagated correctly through props. As fieldset was looking for it in the mitigator response. It doesn't exist there, instead it is supplied by parent components.

## Changes
<!-- what this PR does -->
Add new key to `uploadOptions` - `uploadingText`. Fix prop binding for `uploadOptions`.

## Considerations
<!-- additional info for reviewing, discussion topics -->
`btn-block`class is not needed and has been removed because it causes unwanted conflicting styles.

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests