### PR TITLE
fix fieldset input width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.4.1
+## Fixing broken fieldset width
+Fieldset width without btn-block was breaking, adding width 100%
+
 # v4.4.0
 ## Added new design when persistAsync returns errors
 Added new design when persistAsync returns errors that the user needs to act on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.component.js
+++ b/src/forms/fieldset/fieldset.component.js
@@ -1,5 +1,6 @@
 import controller from './fieldset.controller.js';
 import template from './fieldset.html';
+import './fieldset.less';
 
 const Fieldset = {
   controller,

--- a/src/forms/fieldset/fieldset.html
+++ b/src/forms/fieldset/fieldset.html
@@ -28,7 +28,7 @@
         on-change="$ctrl.fieldChange(value, key, field)"
         on-focus="$ctrl.fieldFocus(key, field)"
         on-blur="$ctrl.fieldBlur(key, field)"
-        class="full-width">
+        class="tw-field-full-width"
         >
       </tw-field>
 
@@ -50,7 +50,7 @@
         on-field-change="$ctrl.fieldChange(value, key, field)"
         on-field-focus="$ctrl.fieldFocus(key, field)"
         on-field-blur="$ctrl.fieldBlur(key, field)"
-        class="full-width">
+        class="tw-field-full-width"
         >
       </tw-fieldset>
     </div>

--- a/src/forms/fieldset/fieldset.html
+++ b/src/forms/fieldset/fieldset.html
@@ -28,6 +28,7 @@
         on-change="$ctrl.fieldChange(value, key, field)"
         on-focus="$ctrl.fieldFocus(key, field)"
         on-blur="$ctrl.fieldBlur(key, field)"
+        class="full-width">
         >
       </tw-field>
 
@@ -49,6 +50,7 @@
         on-field-change="$ctrl.fieldChange(value, key, field)"
         on-field-focus="$ctrl.fieldFocus(key, field)"
         on-field-blur="$ctrl.fieldBlur(key, field)"
+        class="full-width">
         >
       </tw-fieldset>
     </div>

--- a/src/forms/fieldset/fieldset.less
+++ b/src/forms/fieldset/fieldset.less
@@ -1,4 +1,3 @@
-.full-width {
-    width: 100%;
+.tw-field-full-width {
     flex: 1;
 }

--- a/src/forms/fieldset/fieldset.less
+++ b/src/forms/fieldset/fieldset.less
@@ -1,0 +1,4 @@
+.full-width {
+    width: 100%;
+    flex: 1;
+}


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
Before the fieldset used to have a class of btn-block (https://github.com/transferwise/styleguide-components/pull/266/files#diff-d07448f4be0dc1f1b6d4e37ce53fd3b0L53) when this was removed the fieldset was no longer 100%, see screenshots below. Hence adding 100% width to fix this. 

## Changes
<!-- what this PR does -->
Adding width: 100%  and flex:1 to fieldset to get full-width

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->
<img width="1653" alt="Screenshot 2019-12-02 at 11 31 09" src="https://user-images.githubusercontent.com/4820633/69957292-47f77280-14fa-11ea-8ab5-8164012e4dec.png">
### After

<!-- screenshot after change -->
<img width="1538" alt="Screenshot 2019-12-02 at 11 32 13" src="https://user-images.githubusercontent.com/4820633/69957299-4c239000-14fa-11ea-97d7-7cc82289e913.png">

## Checklist

- [ ] All changes are covered by tests