### PR TITLE
At-NaN fix persist async file key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.5.2
+## Fix key for persistAsync
+Key should come from httpOptions or fallback to fieldName
+
 # v4.5.1
 ## Remove elipsis on p
 Removed elipsis on p tag in verification 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/async-file-saver.service.js
+++ b/src/forms/upload/async-file-saver.service.js
@@ -9,7 +9,8 @@ class AsyncFileSaver {
       throw new Error('You must supply httpOptions');
     }
     const formData = new FormData();
-    formData.append(fieldName, file);
+    const key = httpOptions.param || fieldName;
+    formData.append(key, file);
 
     const $httpOptions = prepareHttpOptions(httpOptions);
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
When sending file via httpOptions, param key should come from httpOptions falling back to fieldName

## Changes
<!-- what this PR does -->
Above.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests