### PR TITLE
Fix: made success and error consistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.5.4
+## Fix inconsistency with feedback text on upload
+Success and fail are now h5 and all icons shown on all screen sizes.
+
 # v4.5.3
 ## Fix checking error response
 Due to a http interceptor in frontend common, error can come back with originalData too.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -83,7 +83,7 @@
         <p class="text-ellipsis m-b-2">{{$ctrl.fileName}}</p>
       </div>
       <div ng-if="!$ctrl.hasTranscluded && !$ctrl.isError && $ctrl.successMessage && $ctrl.isImage" ng-style="{'background': 'linear-gradient(rgba(250, 250, 250, 0.9), rgba(250, 250, 250, 0.9)), url({{ $ctrl.image }}) no-repeat center', 'background-size':'contain'}">
-        <div class="m-b-3">
+        <div class="m-b-3 hidden-sm hidden-xs">
           <span class="icon-circle-shadow icon-md">
             <svg height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M6.92 20.06L0 13.32L0.7 12.6L6.92 18.66L23 3L23.7 3.72L6.92 20.06Z" fill="#2ED06E"/>
@@ -103,7 +103,7 @@
         <span class="icon icon-alert icon-xxl text-danger m-b-1"></span>
       </div>
       <div ng-if="!$ctrl.hasTranscluded && $ctrl.isError && $ctrl.errorMessage && $ctrl.isImage" ng-style="{'background': 'linear-gradient(rgba(250, 250, 250, 0.9), rgba(250, 250, 250, 0.9)), url({{ $ctrl.image }}) no-repeat center', 'background-size':'contain'}">
-        <div class="m-b-3"><span class="icon icon-alert icon-circle-shadow icon-md"></span></div>
+        <div class="m-b-3 hidden-sm hidden-xs"><span class="icon icon-alert icon-circle-shadow icon-md"></span></div>
         <h5 class="m-b-2" ng-if="$ctrl.errorMessage">{{$ctrl.errorMessage}}</h5>
         <div class="m-b-3">
           <p ng-if="$ctrl.firstError">{{$ctrl.firstError.message}}</p>

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -90,9 +90,9 @@
             </svg>
           </span>
         </div>
-        <h4 class="m-b-2" ng-if="$ctrl.successMessage">
+        <h5 class="m-b-2" ng-if="$ctrl.successMessage">
           {{$ctrl.successMessage}}
-        </h4>
+        </h5>
         <span class="icon icon-pdf icon-xxl" ng-if="!$ctrl.isImage"></span>
         <p class="m-b-2">{{$ctrl.successDetails}}</p>
       </div>
@@ -103,7 +103,7 @@
         <span class="icon icon-alert icon-xxl text-danger m-b-1"></span>
       </div>
       <div ng-if="!$ctrl.hasTranscluded && $ctrl.isError && $ctrl.errorMessage && $ctrl.isImage" ng-style="{'background': 'linear-gradient(rgba(250, 250, 250, 0.9), rgba(250, 250, 250, 0.9)), url({{ $ctrl.image }}) no-repeat center', 'background-size':'contain'}">
-        <div class="m-b-3 hidden-md hidden-sm hidden-xs"><span class="icon icon-alert icon-circle-shadow icon-md"></span></div>
+        <div class="m-b-3"><span class="icon icon-alert icon-circle-shadow icon-md"></span></div>
         <h5 class="m-b-2" ng-if="$ctrl.errorMessage">{{$ctrl.errorMessage}}</h5>
         <div class="m-b-3">
           <p ng-if="$ctrl.firstError">{{$ctrl.firstError.message}}</p>


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->

## Changes
<!-- what this PR does -->
Success headline was h4
Error headline was h5
now both are h5
fail icon was hidden on MD, SM, XS screens, now showing on all, same ass success icon

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->
<img width="738" alt="Screenshot 2019-12-06 at 09 41 47" src="https://user-images.githubusercontent.com/4820633/70313006-ab401800-180c-11ea-8a2b-30d44e250941.png">
<img width="694" alt="Screenshot 2019-12-06 at 09 41 56" src="https://user-images.githubusercontent.com/4820633/70313007-ab401800-180c-11ea-9b5e-3125f964d92d.png">

### After

<!-- screenshot after change -->
<img width="810" alt="Screenshot 2019-12-06 at 09 39 16" src="https://user-images.githubusercontent.com/4820633/70312944-89469580-180c-11ea-8e18-1acfa428675c.png">

## Checklist

- [ ] All changes are covered by tests