### PR TITLE
Fix spacing on persistAsync feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.5.5
+## Fix spacing on feedback text and CTAs on upload
+Fail scenarios on async upload will have correct spacing between text and CTAs.
+
 # v4.5.4
 ## Fix inconsistency with feedback text on upload
 Success and fail are now h5 and all icons shown on all screen sizes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -106,7 +106,7 @@
         <div class="m-b-3 hidden-sm hidden-xs"><span class="icon icon-alert icon-circle-shadow icon-md"></span></div>
         <h5 class="m-b-2" ng-if="$ctrl.errorMessage">{{$ctrl.errorMessage}}</h5>
         <div class="m-b-3">
-          <p ng-if="$ctrl.firstError">{{$ctrl.firstError.message}}</p>
+          <p ng-if="$ctrl.firstError" class="first-error">{{$ctrl.firstError.message}}</p>
         </div>
         <div class="btn-group-vertical btn-block">
           <label class="btn btn-primary btn-sm m-b-1" ng-click="$ctrl.onUploadButtonClick()" ng-class="{'disabled': $ctrl.ngDisabled}" ng-if="!$ctrl.isLiveCameraUpload">

--- a/src/forms/upload/upload.less
+++ b/src/forms/upload/upload.less
@@ -19,3 +19,9 @@ div.transparent-area {
     top: 0.35em;
     position: relative;
 }
+
+@media (min-width: 576px) {
+    p.first-error {
+        min-height:72px;
+    }
+}


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
To align CTAs on upload component when asking users to reupload.

## Changes
<!-- what this PR does -->
Adds min-height to text to cater for certain size messages

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

![Screenshot 2019-12-05 at 15 21 56](https://user-images.githubusercontent.com/15638344/70315086-c57bf500-1810-11ea-8128-96ab3e96ad0e.png)

### After

<img width="917" alt="Screenshot 2019-12-06 at 09 34 35" src="https://user-images.githubusercontent.com/15638344/70315127-d62c6b00-1810-11ea-9191-eea923323fa4.png">


## Checklist

- [ ] All changes are covered by tests