### PR TITLE
AT-1097 Fix async action failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.5.7
+## Fix upload async actions to not be blocking
+If an async action returns any status code other than 422 than continue with the upload flow as normal.
+
 # v4.5.6
 ## Showing icon on SM screens
 Only hiding icons on success and error on XS screens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -278,7 +278,6 @@ function showDataImage(dataUrl, $ctrl) {
 function asyncSuccess(apiResponse, dataUrl, $ctrl) {
   // Start changing process indicator immediately
   $ctrl.processingState = 1;
-  console.log('SUCCESS CALLED');
 
   if ($ctrl.httpOptions
       && $ctrl.httpOptions.idProperty

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -336,19 +336,19 @@ describe('given an upload component', () => {
         expect(droppable.classList).toContain('droppable-complete');
       });
 
-      it('should show the failure message', function() {
+      it('should not show the failure message', function() {
         expect(directiveElement.querySelector('.upload-failure-message')).toBeFalsy();
       });
 
-      it('should not bind anything to the model', function() {
+      it('should bind base64url to the model', function() {
         expect($scope.ngModel).toBe(base64url);
       });
 
-      it('should not call the onSuccess handler', function() {
+      it('should call the onSuccess handler', function() {
         expect($scope.onSuccess).toHaveBeenCalled();
       });
 
-      it('should call the onFailure handler', function() {
+      it('should call not the onFailure handler', function() {
         expect($scope.onFailure).not.toHaveBeenCalled();
       });
     });

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -322,9 +322,44 @@ describe('given an upload component', () => {
       });
     });
 
-    describe('when the timer has elapsed and the request was rejected', function() {
+    describe('when the timer has elapsed and the request failed', function() {
       beforeEach(function() {
-        deferred.reject({});
+        deferred.reject({ status:500 });
+        $timeout.flush(4100);
+      });
+
+      it('should not show the processing screen', function() {
+        expect(droppable.classList).not.toContain('droppable-processing');
+      });
+
+      it('should show the complete screen', function() {
+        expect(droppable.classList).toContain('droppable-complete');
+      });
+
+      it('should show the failure message', function() {
+        expect(directiveElement.querySelector('.upload-failure-message')).toBeFalsy();
+      });
+
+      it('should not bind anything to the model', function() {
+        expect($scope.ngModel).toBe(base64url);
+      });
+
+      it('should not call the onSuccess handler', function() {
+        expect($scope.onSuccess).toHaveBeenCalled();
+      });
+
+      it('should call the onFailure handler', function() {
+        expect($scope.onFailure).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the timer has elapsed and the request returns 422', function() {
+      beforeEach(function() {
+        deferred.reject({
+          status: 422,
+          data: { message: "Sorry, unreadable", errors: ["Too blurry"] }
+        });
+        console.log('FOUR FOU TWO SPEC');
         $timeout.flush(4100);
       });
 

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -359,7 +359,6 @@ describe('given an upload component', () => {
           status: 422,
           data: { message: "Sorry, unreadable", errors: ["Too blurry"] }
         });
-        console.log('FOUR FOU TWO SPEC');
         $timeout.flush(4100);
       });
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
If an async action with upload, example persistAsync, fails. We don't want to halt the original flow or submitting the dataUrl. Only if the async action fails with a 422 with information to display to user, should be continue with the async action flow.

## Changes
<!-- what this PR does -->
Check error response for status code and continue as normal if not 422.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests