### PR TITLE
Single file upload fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.1.1
+## Fix single file upload
+Fix for single file upload where the user has to click on the upload button again to start the upload
+
 # v5.1.0
 ## Multi upload component
 Add multi upload component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/processing-card/index.js
+++ b/src/forms/upload/processing-card/index.js
@@ -5,13 +5,15 @@ import AsyncFileReader from '../services/async-file-reader.service.js';
 import AsyncFileSaver from '../services/async-file-saver.service.js';
 import FileValidationService from '../services/file-validation.service.js';
 import AsyncTasksConfig from '../../../services/asyncTasksConfig';
+import Process from '../../../loading/process';
 
 export default angular
   .module('tw.styleguide.forms.upload.processing', [
     AsyncTasksConfig,
     AsyncFileReader,
     AsyncFileSaver,
-    FileValidationService
+    FileValidationService,
+    Process
   ])
   .component('twUploadProcessing', ProcessingCard)
   .component('twUploadProcessingMini', ProcessingMini)

--- a/src/forms/upload/processing-card/processing-card.html
+++ b/src/forms/upload/processing-card/processing-card.html
@@ -3,7 +3,6 @@
     <tw-process
       size="sm"
       state="$ctrl.processingState"
-      ng-if="$ctrl.isProcessing"
     ></tw-process>
   </div>
 

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -28,6 +28,26 @@ describe('given an upload component', () => {
     });
   });
 
+  it('initially starts an interval to check for state changes', () => {
+    const template = " \
+    <tw-upload \
+      too-large-message='File is too large' \
+      processing-text='processing' \
+      success-text='success'\
+      failure-text='failure' \
+      on-start='onStart' \
+      on-success='onSuccess' \
+      on-failure='onFailure' \
+      on-cancel='onCancel' \
+      max-size='10'> \
+    </tw-upload>";  
+
+    directiveElement = getCompiledDirectiveElement($scope, template);
+    const processingElement = angular.element(directiveElement.querySelector('tw-process'));
+
+    expect(processingElement.isolateScope().$ctrl.interval).not.toEqual(null);
+  });
+
   describe('when a file is dropped', () => {
     let dropTarget;
     let deferred;

--- a/src/loading/process/process.controller.js
+++ b/src/loading/process/process.controller.js
@@ -5,6 +5,7 @@ class ProcessController {
 
     this.interval = null;
     this.processing = this.state;
+    this.onStateChange();
   }
 
   $onChanges(changes) {


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
Single file upload was not triggering a processing start initially outside of the demo. The user would have to click on the upload button again after selecting a file to trigger the process to start.

## Changes
- Always render `tw-process` component in the single file upload
- call `onStateChange` initially to begin the interval to check for state change

## Screenshots/GIFs
<!-- required for all visual changes -->
![singleupload](https://user-images.githubusercontent.com/57909099/76210830-d4ea5000-61fc-11ea-97c0-490528d16ca9.gif)


## Checklist

- [X] All changes are covered by tests