### PR TITLE
Remove 422 only failures for upload components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v5.2.0
+# v5.1.2
 ## Remove failure for upload component on 422 only
 Fail on any error status instead of 422 only for upload components. Multi-file upload bug fix when user clicks cancel after uploading.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v6.0.0
+## Remove failure for upload component on 422 only
+Fail on any error status instead of 422 only for upload components. Multi-file upload bug fix when user clicks cancel after uploading.
+
 # v5.1.1
 ## Fix single file upload
 Fix for single file upload where the user has to click on the upload button again to start the upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v6.0.0
+# v5.2.0
 ## Remove failure for upload component on 422 only
 Fail on any error status instead of 422 only for upload components. Multi-file upload bug fix when user clicks cancel after uploading.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.2.0",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "6.0.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "6.0.0",
+  "version": "5.2.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.2.0",
+  "version": "5.1.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.1",
+  "version": "6.0.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/multi-upload/multi-upload.controller.js
+++ b/src/forms/upload/multi-upload/multi-upload.controller.js
@@ -27,6 +27,10 @@ class Controller {
       throw new Error('Could not retrieve file');
     }
 
+    if (files.length === 0) {
+      return;
+    }
+
     if (this.onStart && this.areAllFilesProcessed()) {
       this.onStart();
     }

--- a/src/forms/upload/multi-upload/multi-upload.spec.js
+++ b/src/forms/upload/multi-upload/multi-upload.spec.js
@@ -302,7 +302,7 @@ describe("multi-upload", () => {
           ]);
         });
 
-        fdescribe('when the user clicks cancel on file browser', () => {
+        describe('when the user clicks cancel on file browser', () => {
           beforeEach(() => {
             const fakeDropEvent = new CustomEvent("drop");
 

--- a/src/forms/upload/multi-upload/multi-upload.spec.js
+++ b/src/forms/upload/multi-upload/multi-upload.spec.js
@@ -538,7 +538,7 @@ describe("multi-upload", () => {
         });
 
         it("returns a model with NO IDs", () => {
-          expect($scope.ngModel).toEqual([]);
+          expect($scope.ngModel).toEqual(null);
         });
       });
     });

--- a/src/forms/upload/multi-upload/multi-upload.spec.js
+++ b/src/forms/upload/multi-upload/multi-upload.spec.js
@@ -301,6 +301,23 @@ describe("multi-upload", () => {
             base64url
           ]);
         });
+
+        fdescribe('when the user clicks cancel on file browser', () => {
+          beforeEach(() => {
+            const fakeDropEvent = new CustomEvent("drop");
+
+            // simulate cancel
+            fakeDropEvent.dataTransfer = { files: [] };
+  
+            dropTarget.dispatchEvent(fakeDropEvent);
+  
+            $timeout.flush(5000);      
+          });
+
+          it('calls onStart once from previous drop event ONLY', () => {
+            expect($scope.onStart.calls.count()).toBe(1);
+          });
+        });
       });
     });
   });

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -52,16 +52,7 @@ class Controller {
       // Post file now
       this.asyncFileRead(file)
         .then(dataUrl => this.asyncFileSave(file)
-          .then(response => asyncSuccess(response, dataUrl, this))
-          .catch((error) => {
-            if (error.status === 422) {
-              // Note: Only if async action returns 422, do we want to process that error
-              asyncFailure(error, dataUrl, this);
-            } else {
-              // Note: If async action fails, we continue with original flow
-              asyncSuccess(null, dataUrl, this);
-            }
-          }))
+          .then(response => asyncSuccess(response, dataUrl, this)))
         .catch(error => asyncFailure(error, null, this));
     } else {
       // Post on form submit

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -251,41 +251,7 @@ describe('given an upload component', () => {
     describe('when the timer has elapsed and the request failed', function() {
       beforeEach(function() {
         deferred.reject({ status:500 });
-        $timeout.flush(4100);
-      });
-
-      it('should not show the processing screen', function() {
-        expect(droppable.classList).not.toContain('droppable-processing');
-      });
-
-      it('should show the complete screen', function() {
-        expect(droppable.classList).toContain('droppable-complete');
-      });
-
-      it('should not show the failure message', function() {
-        expect(directiveElement.querySelector('.upload-failure-message')).toBeFalsy();
-      });
-
-      it('should bind base64url to the model', function() {
-        expect($scope.ngModel).toBe(base64url);
-      });
-
-      it('should call the onSuccess handler', function() {
-        expect($scope.onSuccess).toHaveBeenCalled();
-      });
-
-      it('should call not the onFailure handler', function() {
-        expect($scope.onFailure).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('when the timer has elapsed and the request returns 422', function() {
-      beforeEach(function() {
-        deferred.reject({
-          status: 422,
-          data: { message: "Sorry, unreadable", errors: ["Too blurry"] }
-        });
-        $timeout.flush(4100);
+        $timeout.flush(4200);
       });
 
       it('should not remain on the processing screen', function() {
@@ -300,11 +266,11 @@ describe('given an upload component', () => {
         expect(directiveElement.querySelector('.upload-failure-message')).toBeTruthy();
       });
 
-      it('should not bind anything to the model', function() {
-        expect($scope.ngModel).toBe(null);
+      it('should NOT bind base64url to the model', function() {
+        expect($scope.ngModel).not.toBe(base64url);
       });
 
-      it('should not call the onSuccess handler', function() {
+      it('should NOT call the onSuccess handler', function() {
         expect($scope.onSuccess).not.toHaveBeenCalled();
       });
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
When we use persistAsync and the service returns a non 422 error, we should treat it as an error in the component instead of succeeding.

## Changes
Treat any error status codes as errors in the upload components

## Considerations
This will break the existing behaviour of ID checking since if the image upload fails with a 422, the user will not be able to carry on with the flow. This has been discussed and will only affect a small percentage of users

## Checklist

- [X] All changes are covered by tests