### PR TITLE
Display errors which are returned from persistAsync for multi file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# v5.1.3
-## Wire errors from backend to multi-file upload
-Errors coming back from persistAsync response are shown in multi-file upload. Add tooLargeMessage to multi-file upload as well.
+# v5.2.0
+## Add onFailure callback when file fails to upload for multi-file upload
+onFailure is now called whenever a file fails to upload with an error object. Renamed 'secondaryButtonText' to 'addMoreButtonText'.
+
 
 # v5.1.2
 ## Remove failure for upload component on 422 only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.1.3
+## Wire errors from backend to multi-file upload
+Errors coming back from persistAsync response are shown in multi-file upload. Add tooLargeMessage to multi-file upload as well.
+
 # v5.1.2
 ## Remove failure for upload component on 422 only
 Fail on any error status instead of 422 only for upload components. Multi-file upload bug fix when user clicks cancel after uploading.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/multi-upload/multi-upload.component.js
+++ b/src/forms/upload/multi-upload/multi-upload.component.js
@@ -14,7 +14,7 @@ const Component = {
     icon: '@', // illustration in icon shown in upload box
 
     buttonText: '@', // Button text shown in default state
-    secondaryButtonText: '@', // Button text shown in processing state
+    addMoreButtonText: '@', // Button text shown in processing state
 
     droppingText: '@', // Text shown when hovering with a file
     processingText: '@', // Text shown while processing/uploading

--- a/src/forms/upload/multi-upload/multi-upload.component.js
+++ b/src/forms/upload/multi-upload/multi-upload.component.js
@@ -28,6 +28,7 @@ const Component = {
 
     onStart: '&',
     onFinish: '&',
+    onFailure: '&',
 
     accept: '@',
     httpOptions: '<',

--- a/src/forms/upload/multi-upload/multi-upload.component.js
+++ b/src/forms/upload/multi-upload/multi-upload.component.js
@@ -14,7 +14,7 @@ const Component = {
     icon: '@', // illustration in icon shown in upload box
 
     buttonText: '@', // Button text shown in default state
-    addMoreButtonText: '@', // Button text shown in processing state
+    addMoreButtonText: '@', // Button text shown when at least one file is uploading
 
     droppingText: '@', // Text shown when hovering with a file
     processingText: '@', // Text shown while processing/uploading

--- a/src/forms/upload/multi-upload/multi-upload.controller.js
+++ b/src/forms/upload/multi-upload/multi-upload.controller.js
@@ -70,6 +70,10 @@ class Controller {
   onProcessFailure(index, file, error) {
     this.files[index].error = error;
 
+    if (this.onFailure) {
+      this.onFailure({ error });
+    }
+
     if (this.onFinish && this.areAllFilesProcessed()) {
       this.onFinish();
     }

--- a/src/forms/upload/multi-upload/multi-upload.demo.html
+++ b/src/forms/upload/multi-upload/multi-upload.demo.html
@@ -36,7 +36,6 @@
         cancel-text="{{$ctrl.cancelText}}"
 
         too-large-message="{{$ctrl.tooLargeMessage}}"
-        error-message="{{$ctrl.errorMessage}}"
 
         dropping-text="{{$ctrl.droppingText}}"
         processing-text="{{$ctrl.processingText}}"
@@ -64,18 +63,17 @@
   wrong-type-text="{{$ctrl.wrongTypeMessage}}"</span><span ng-if="$ctrl.maxSize">
   max-size="{{$ctrl.maxSize}}"
   too-large-message="{{$ctrl.tooLargeMessage}}"</span><span ng-if="$ctrl.droppingText">
-  processing-text="{{$ctrl.droppingText}}"</span><span ng-if="$ctrl.processingText">
+  dropping-text="{{$ctrl.droppingText}}"</span><span ng-if="$ctrl.processingText">
   processing-text="{{$ctrl.processingText}}"</span><span ng-if="$ctrl.successText">
-  success-text="{{$ctrl.successText}}"</span><span ng-if="$ctrl.failureText">
-  failure-text="{{$ctrl.failureText}}"</span><span ng-if="$ctrl.httpOptions">
+  success-text="{{$ctrl.successText}}"</span><span ng-if="$ctrl.httpOptions">
   http-options="{{$ctrl.httpOptions}}"</span><span ng-if="$ctrl.errorMessage">
-  error-message="{{$ctrl.errorMessage}}"</span>
+  error-message="{{$ctrl.errorMessage}}"</span><span ng-if="$ctrl.secondaryButtonText">
+  secondary-button-text="{{$ctrl.secondaryButtonText}}"</span>
   on-start="$ctrl.onStart"
   on-finish="$ctrl.onFinish"
   </span><span ng-if="$ctrl.source">
   source="{{$ctrl.source}}"</span><span ng-if="$ctrl.ngDisabled">
-  ng-disabled="{{$ctrl.ngDisabled}}"</span><span ng-if="$ctrl.secondaryButtonText">
-  secondary-button-text="{{$ctrl.secondaryButtonText}}"</span>&gt;
+  ng-disabled="{{$ctrl.ngDisabled}}"</span>&gt;
 &lt;/tw-multi-upload&gt;
 </pre>
   </div>

--- a/src/forms/upload/multi-upload/multi-upload.demo.html
+++ b/src/forms/upload/multi-upload/multi-upload.demo.html
@@ -15,6 +15,7 @@
 <ul>
   <li><p><code>on-start()</code> - fired when we start processing the files. If more files are added whilst files are still being processed the event is not fired.</p></li>
   <li><p><code>on-finish()</code> - fired when all files which are in the processing screen have finished. If http-options are passed then the finish event is fired when all the files have been uploaded to the server.</li>
+  <li><p><code>on-failure(error)</code> - fired when a file has failed. The error is available in which an error message can be extracted and passed back to the component as failure-text.</li>
 </ul>
 
 <form action="/file" method="POST" enctype="multipart/form-data">
@@ -44,6 +45,7 @@
 
         on-start="$ctrl.onStart()"
         on-finish="$ctrl.onFinish()"
+        on-failure="$ctrl.onFailure(error)"
 
         http-options="$ctrl.httpOptions"
         ng-disabled="$ctrl.ngDisabled"
@@ -71,6 +73,7 @@
   secondary-button-text="{{$ctrl.secondaryButtonText}}"</span>
   on-start="$ctrl.onStart"
   on-finish="$ctrl.onFinish"
+  on-failure="$ctrl.onFailure(error)"
   </span><span ng-if="$ctrl.source">
   source="{{$ctrl.source}}"</span><span ng-if="$ctrl.ngDisabled">
   ng-disabled="{{$ctrl.ngDisabled}}"</span>&gt;

--- a/src/forms/upload/multi-upload/multi-upload.demo.html
+++ b/src/forms/upload/multi-upload/multi-upload.demo.html
@@ -33,7 +33,7 @@
         placeholder="{{$ctrl.placeholder}}"
 
         button-text="{{$ctrl.buttonText}}"
-        secondary-button-text="{{$ctrl.secondaryButtonText}}"
+        add-more-button-text="{{$ctrl.addMoreButtonText}}"
         cancel-text="{{$ctrl.cancelText}}"
 
         too-large-message="{{$ctrl.tooLargeMessage}}"
@@ -69,8 +69,8 @@
   processing-text="{{$ctrl.processingText}}"</span><span ng-if="$ctrl.successText">
   success-text="{{$ctrl.successText}}"</span><span ng-if="$ctrl.httpOptions">
   http-options="{{$ctrl.httpOptions}}"</span><span ng-if="$ctrl.errorMessage">
-  error-message="{{$ctrl.errorMessage}}"</span><span ng-if="$ctrl.secondaryButtonText">
-  secondary-button-text="{{$ctrl.secondaryButtonText}}"</span>
+  error-message="{{$ctrl.errorMessage}}"</span><span ng-if="$ctrl.addMoreButtonText">
+  add-more-button-text="{{$ctrl.addMoreButtonText}}"</span>
   on-start="$ctrl.onStart"
   on-finish="$ctrl.onFinish"
   on-failure="$ctrl.onFailure(error)"
@@ -114,11 +114,11 @@
         <input type="text" class="form-control" ng-model="$ctrl.buttonText" />
       </div>
 
-      <div class="form-group" ng-init="$ctrl.secondaryButtonText = 'Add more files'">
+      <div class="form-group" ng-init="$ctrl.addMoreButtonText = 'Add more files'">
         <label class="control-label">
-          Secondary button text
+          Add more button text
         </label>
-        <input type="text" class="form-control" ng-model="$ctrl.secondaryButtonText" />
+        <input type="text" class="form-control" ng-model="$ctrl.addMoreButtonText" />
       </div>
     
       <div class="form-group">

--- a/src/forms/upload/multi-upload/multi-upload.demo.js
+++ b/src/forms/upload/multi-upload/multi-upload.demo.js
@@ -7,7 +7,13 @@ class AsyncFileSaverMock {
     this.$q = $q;
   }
 
-  save() {
+  save(fieldName, file, httpOptions) {
+    if (httpOptions.url === '404') {
+      return this.$q.reject({
+        data: { message: 'Error message from server' }
+      });
+    }
+
     return this.$q.resolve({
       data: {
         id: 1234,

--- a/src/forms/upload/multi-upload/multi-upload.demo.js
+++ b/src/forms/upload/multi-upload/multi-upload.demo.js
@@ -10,7 +10,7 @@ class AsyncFileSaverMock {
   save(fieldName, file, httpOptions) {
     if (httpOptions.url === '404') {
       return this.$q.reject({
-        data: { message: 'Error message from server' }
+        data: {}
       });
     }
 
@@ -48,6 +48,10 @@ function controller($scope) {
   $ctrl.successText = 'Upload complete!';
   $ctrl.failureText = 'Upload failed!';
   $ctrl.secondaryButtonText = 'Add more files';
+
+  $ctrl.onFailure = (error) => {
+    $ctrl.failureText = error.data.message || $ctrl.failureText;
+  };
 
   this.makeFancy = () => {};
 

--- a/src/forms/upload/multi-upload/multi-upload.demo.js
+++ b/src/forms/upload/multi-upload/multi-upload.demo.js
@@ -47,7 +47,7 @@ function controller($scope) {
   $ctrl.droppingText = 'Drag files to upload';
   $ctrl.successText = 'Upload complete!';
   $ctrl.failureText = 'Upload failed!';
-  $ctrl.secondaryButtonText = 'Add more files';
+  $ctrl.addMoreButtonText = 'Add more files';
 
   $ctrl.onFailure = (error) => {
     $ctrl.failureText = error.data.message || $ctrl.failureText;

--- a/src/forms/upload/multi-upload/multi-upload.html
+++ b/src/forms/upload/multi-upload/multi-upload.html
@@ -59,7 +59,7 @@
     <tw-upload-button
       ng-if="!$ctrl.isLiveCameraUpload"
       name="$ctrl.name"
-      label="$ctrl.files.length === 0 ? $ctrl.buttonText : $ctrl.secondaryButtonText"
+      label="$ctrl.files.length === 0 ? $ctrl.buttonText : $ctrl.addMoreButtonText"
       is-secondary="$ctrl.files.length > 0"
       accept="$ctrl.accept"
       model="$ctrl.inputFile"

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -109,8 +109,7 @@ function asyncSuccess(response, dataUrl, $ctrl) {
 function asyncFailure(error, dataUrl, $ctrl) {
   // Start changing process indicator immediately
   $ctrl.processingState = -1;
-  // use the server error message if one exists, else default to the provided error message
-  $ctrl.error = (error && error.data && error.data.message) || $ctrl.errorMessage;
+
   // Wait before updating text
   $ctrl.$timeout(() => {
     $ctrl.isProcessing = false;
@@ -119,7 +118,7 @@ function asyncFailure(error, dataUrl, $ctrl) {
   // Allow a small amount of extra time before notifying external handlers
   $ctrl.$timeout(() => {
     $ctrl.onFailure({ error });
-  }, 4100); // 3500); TODO for some reason more time is needed
+  }, 3600); // 3500); TODO for some reason more time is needed
 
   return error;
 }

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -43,7 +43,7 @@ class Controller {
       this.validationMessages = [this.tooLargeMessage];
       asyncFailure({
         status: 413,
-        statusText: 'Request Entity Too Large'
+        data: { message: this.tooLargeMessage }
       }, null, this);
       return;
     }
@@ -109,6 +109,8 @@ function asyncSuccess(response, dataUrl, $ctrl) {
 function asyncFailure(error, dataUrl, $ctrl) {
   // Start changing process indicator immediately
   $ctrl.processingState = -1;
+  // use the server error message if one exists, else default to the provided error message
+  $ctrl.error = (error && error.data && error.data.message) || $ctrl.errorMessage;
   // Wait before updating text
   $ctrl.$timeout(() => {
     $ctrl.isProcessing = false;

--- a/src/forms/upload/processing-card/processing-mini.html
+++ b/src/forms/upload/processing-card/processing-mini.html
@@ -11,7 +11,7 @@
         <small class="m-b-0 text-ellipsis file-name"><strong>{{ $ctrl.file.name }}</strong></small>
         <small class="m-b-0 text-ellipsis tiny">
           <span ng-if="$ctrl.isProcessing">{{ $ctrl.processingMessage }}</span>
-          <span ng-if="$ctrl.isError">{{ $ctrl.error }}</span>
+          <span ng-if="$ctrl.isError">{{ $ctrl.errorMessage }}</span>
           <span ng-if="$ctrl.isSuccess">{{ $ctrl.successMessage }}</span>
         </small>
       </div>

--- a/src/forms/upload/processing-card/processing-mini.html
+++ b/src/forms/upload/processing-card/processing-mini.html
@@ -11,7 +11,7 @@
         <small class="m-b-0 text-ellipsis file-name"><strong>{{ $ctrl.file.name }}</strong></small>
         <small class="m-b-0 text-ellipsis tiny">
           <span ng-if="$ctrl.isProcessing">{{ $ctrl.processingMessage }}</span>
-          <span ng-if="$ctrl.isError">{{ $ctrl.errorMessage }}</span>
+          <span ng-if="$ctrl.isError">{{ $ctrl.error }}</span>
           <span ng-if="$ctrl.isSuccess">{{ $ctrl.successMessage }}</span>
         </small>
       </div>

--- a/src/forms/upload/upload.demo.js
+++ b/src/forms/upload/upload.demo.js
@@ -7,7 +7,13 @@ class AsyncFileSaverMock {
     this.$q = $q;
   }
 
-  save() {
+  save(fieldName, file, httpOptions) {
+    if (httpOptions.url === '404') {
+      return this.$q.reject({
+        data: { message: 'Error message from server' }
+      });
+    }
+
     return this.$q.resolve({
       data: {
         id: 1234,


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
Currently we only show the "failure-text" property if the upload fails. This is too vague.

## Changes
- Display the `tooLargeMessage` passed in by the consumer if the file is too large
- Provides an onFailure callback which exposes the error. an error message can be extracted and passed as failure-text back to the component
- Rename "secondaryButtonText" to "addMoreButtonText"

## Screenshots/GIFs
Failure due to file size:
<img width="404" alt="Screenshot 2020-03-13 at 17 35 13" src="https://user-images.githubusercontent.com/57909099/76645692-6a654700-6551-11ea-85ff-1eb08b2ab02f.png">
Failure due to server error:
<img width="407" alt="Screenshot 2020-03-13 at 17 35 38" src="https://user-images.githubusercontent.com/57909099/76645695-6afddd80-6551-11ea-8a35-6a224b953044.png">
Failure where client can't extract error message from server:
<img width="407" alt="Screenshot 2020-03-13 at 17 38 00" src="https://user-images.githubusercontent.com/57909099/76645696-6b967400-6551-11ea-8562-d5deaa7a9fa5.png">


## Checklist

- [X] All changes are covered by tests