### PR TITLE
add responseErrorExtractor callback for error message extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.3.0
+## Add responseErrorExtractor to multi file upload
+responseErrorExtractor now called whenever a file fails to upload with an error object.
+
 # v5.2.0
 ## Add onFailure callback when file fails to upload for multi-file upload
 onFailure is now called whenever a file fails to upload with an error object. Renamed 'secondaryButtonText' to 'addMoreButtonText'.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/multi-upload/multi-upload.component.js
+++ b/src/forms/upload/multi-upload/multi-upload.component.js
@@ -29,6 +29,7 @@ const Component = {
     onStart: '&',
     onFinish: '&',
     onFailure: '&',
+    responseErrorExtractor: '&',
 
     accept: '@',
     httpOptions: '<',

--- a/src/forms/upload/multi-upload/multi-upload.demo.html
+++ b/src/forms/upload/multi-upload/multi-upload.demo.html
@@ -15,7 +15,8 @@
 <ul>
   <li><p><code>on-start()</code> - fired when we start processing the files. If more files are added whilst files are still being processed the event is not fired.</p></li>
   <li><p><code>on-finish()</code> - fired when all files which are in the processing screen have finished. If http-options are passed then the finish event is fired when all the files have been uploaded to the server.</li>
-  <li><p><code>on-failure(error)</code> - fired when a file has failed. The error is available in which an error message can be extracted and passed back to the component as failure-text.</li>
+  <li><p><code>on-failure(error)</code> - fired when a file has failed. The error is available in which an error message can be extracted.</li>
+  <li><p><code>response-error-extractor(error)</code> - called when an error occurs on upload. Provide this function when you want to extract an error message from the response. The provided function should return the string you want to display</li>
 </ul>
 
 <form action="/file" method="POST" enctype="multipart/form-data">
@@ -47,6 +48,8 @@
         on-finish="$ctrl.onFinish()"
         on-failure="$ctrl.onFailure(error)"
 
+        response-error-extractor="$ctrl.responseErrorExtractor(error)"
+
         http-options="$ctrl.httpOptions"
         ng-disabled="$ctrl.ngDisabled"
       ></tw-multi-upload>
@@ -74,6 +77,7 @@
   on-start="$ctrl.onStart"
   on-finish="$ctrl.onFinish"
   on-failure="$ctrl.onFailure(error)"
+  response-error-extractor="$ctrl.responseErrorExtractor(error)"
   </span><span ng-if="$ctrl.source">
   source="{{$ctrl.source}}"</span><span ng-if="$ctrl.ngDisabled">
   ng-disabled="{{$ctrl.ngDisabled}}"</span>&gt;

--- a/src/forms/upload/multi-upload/multi-upload.demo.js
+++ b/src/forms/upload/multi-upload/multi-upload.demo.js
@@ -49,9 +49,7 @@ function controller($scope) {
   $ctrl.failureText = 'Upload failed!';
   $ctrl.addMoreButtonText = 'Add more files';
 
-  $ctrl.onFailure = (error) => {
-    $ctrl.failureText = error.data.message || $ctrl.failureText;
-  };
+  $ctrl.responseErrorExtractor = error => error.data.message || $ctrl.failureText;
 
   this.makeFancy = () => {};
 

--- a/src/forms/upload/multi-upload/multi-upload.html
+++ b/src/forms/upload/multi-upload/multi-upload.html
@@ -51,6 +51,7 @@
         validation-messages="$ctrl.validationMessages"
         too-large-message="$ctrl.tooLargeMessage"
         cancel-text="$ctrl.cancelText"
+        response-error-extractor="$ctrl.responseErrorExtractor({error})"
       ></tw-upload-processing-mini>
     </div>
   </div>

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -110,6 +110,10 @@ function asyncFailure(error, dataUrl, $ctrl) {
   // Start changing process indicator immediately
   $ctrl.processingState = -1;
 
+  if ($ctrl.responseErrorExtractor) {
+    $ctrl.errorMessage = $ctrl.responseErrorExtractor({ error }) || $ctrl.errorMessage;
+  }
+
   // Wait before updating text
   $ctrl.$timeout(() => {
     $ctrl.isProcessing = false;

--- a/src/forms/upload/processing-card/processing.bindings.js
+++ b/src/forms/upload/processing-card/processing.bindings.js
@@ -6,6 +6,7 @@ export default {
   onSuccess: '&',
   onFailure: '&',
   onCancel: '&',
+  responseErrorExtractor: '&',
 
   maxSize: '<',
   accept: '<',


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
We want to display errors per file. The onFailure handler only modifies the root failureText which would change all error messages.

## Changes
<!-- what this PR does -->
Provides a responseErrorExtractor which is called when a file fails to upload. This function is passed the error object in which the message can be extracted and returned. The resulting error message is then assigned to `$ctrl.errorMessage` in `processing-card.controller.js`.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<img width="412" alt="Screenshot 2020-03-17 at 17 44 03" src="https://user-images.githubusercontent.com/57909099/76888650-32754100-687c-11ea-9231-18afa1952d2d.png">

<img width="401" alt="Screenshot 2020-03-17 at 17 47 30" src="https://user-images.githubusercontent.com/57909099/76888719-5042a600-687c-11ea-9e80-f291cd5705d4.png">



## Checklist

- [X] All changes are covered by tests