### PR TITLE
fix(twSelect): manually trigger ngChange when option is manually set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.3.1
+## twSelect calls ngChange when the ngModel and ngRequired are set
+Fixes a bug when ngRequired is set to true and a valid ngModel is passed to the component, but parent component was not notified via ngChange callback.
+
 # v5.3.0
 ## Add responseErrorExtractor to multi file upload
 responseErrorExtractor now called whenever a file fails to upload with an error object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/select/select.component.js
+++ b/src/forms/select/select.component.js
@@ -8,6 +8,7 @@ const Select = {
   transclude: true,
   bindings: {
     ngModel: '=',
+    ngChange: '&',
     ngRequired: '<',
     ngDisabled: '<',
     options: '<',

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -18,7 +18,7 @@ class SelectController {
     this.search = '';
 
     preSelectModelValue(this.$ngModel, this);
-    setDefaultIfRequired(this.$ngModel, this, this.$element, this.$attrs);
+    setDefaultIfRequired(this.$ngModel, this, this.$attrs, this.$timeout);
 
     addEventHandlers(this, this.$element, this.$ngModel, this.options, this.$timeout);
 
@@ -35,6 +35,8 @@ class SelectController {
   }
 
   $onChanges(changes) {
+    console.log(this.ngChange);
+    console.log('adasdasd');
     if (changes.options) {
       this.onOptionsChange(
         changes.options.currentValue,
@@ -61,7 +63,7 @@ class SelectController {
   onOptionsChange(newValue, oldValue) {
     if (newValue !== oldValue) {
       preSelectModelValue(this.$ngModel, this);
-      setDefaultIfRequired(this.$ngModel, this, this.$element, this.$attrs);
+      setDefaultIfRequired(this.$ngModel, this, this.$attrs, this.$timeout);
       this.filteredOptions = this.getFilteredOptions();
     }
   }
@@ -405,12 +407,13 @@ function findOptionFromValue(options, value) {
   return optionMatch;
 }
 
-function setDefaultIfRequired($ngModel, $ctrl, $element, $attrs) {
+function setDefaultIfRequired($ngModel, $ctrl, $attrs, $timeout) {
   // If required and model empty, select first option with value
   if (($ctrl.ngRequired || $attrs.required) && !isValidModel($ctrl.ngModel) && !$ctrl.placeholder) {
     for (let i = 0; i < $ctrl.options.length; i++) {
       if (isValidModel($ctrl.options[i].value)) {
         selectOption($ngModel, $ctrl, $ctrl.options[i]);
+        $timeout($ctrl.ngChange);
         break;
       }
     }

--- a/src/forms/select/select.controller.js
+++ b/src/forms/select/select.controller.js
@@ -35,8 +35,6 @@ class SelectController {
   }
 
   $onChanges(changes) {
-    console.log(this.ngChange);
-    console.log('adasdasd');
     if (changes.options) {
       this.onOptionsChange(
         changes.options.currentValue,


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
When a `twSelect` component is rendered with a valid `ngModel` and the `ngRequired` binding is set to `true` the parent component of `twSelect` did not got updated.

#### What should happen in this cases in`twSelect`?
When a valid `ngModel` is present and `ngRequired` is set to true, the `twSelect` component should set the `ngModel` to the first option from the provided options which has a valid `value` property. This was already working, but the parent component of `twSelect` was not notified about this manual configuration step in `twSelect`.

## Changes
<!-- what this PR does -->
`setDefaultIfRequired` implementation modified. This method now calls `$ctrl.ngChange` binding manually, wrapped into a `$timeout`.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->
![Screen-Recording-2020-03-26-at-20 21 45](https://user-images.githubusercontent.com/11005750/77688262-12423200-6fa0-11ea-8ea4-e593db7249d9.gif)


### After

<!-- screenshot after change -->
![Screen-Recording-2020-03-26-at-20 23 06](https://user-images.githubusercontent.com/11005750/77688281-166e4f80-6fa0-11ea-933f-a5561f268918.gif)


## Checklist

- [ ] All changes are covered by tests