### PR TITLE
Leave notes in the readme for testing when on Ubuntu 16.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.4.1
+## Readme update only, for advice on running tests on Ubuntu 16.04
+
 # v5.4.0
 ## Markdown component
 Introduce markdown component

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ To run the local server with live reload you can run the following:
 npm run dev
 ```
 
+### Testing
+
+To test, run `npm test`.
+
+If you get errors while testing along the lines of:
+
+```
+libpng16.so.16: cannot open shared object file: No such file or directory
+
+    at Object.<anonymous> (node_modules/canvas/lib/bindings.js:3:18)
+```
+
+Then be sure to install the necessary dependencies for your OS by following https://www.npmjs.com/package/canvas#compiling.
+
+If you still can't able to find `libpcre.so.1`, and you're (still) on Ubuntu 16.04, well there's no `libpcre.so.1` in the apt packages. Take guidance from [this StackOverflow comment](https://stackoverflow.com/questions/43301339/pcre-issue-when-setting-up-wsgi-application#comment73670596_43301339). You will need to download and extract the latest pcre-8.XX package from https://www.pcre.org/, `./configure`, `make`, (sudo-)move the resulting `.lib/libpcre.so.1.X.X` to maybe `/usr/lib`, update its permissions, and `ln -s` `libpcre.so.1` to it.
+
+
 ## Releasing
 
 In order to release a new version, here are the steps necessary:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
Because when you run `npm test` on Ubuntu 16.04, you may get complaints about a bunch of missing dependencies. Most of them can be resolved by `apt install`, 1 can't and you'll have to manually compile it.

## Changes
Updates the readme.

## Considerations
Consider how glad I am to be able to run tests now.

## Original Pull Request (for version bumps)
\-

## Checklist

- [ ] ~All changes are covered by tests~