### PR TITLE
Markdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v5.4.0
+## Markdown component
+Introduce markdown component
+
 # v5.3.2
 ## Use JPEG compression for camera upload image
 We were using png before for camera uploads and the image was too big. This update reduces image size from camera upload component by up to 10x.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,6 +3869,24 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "commonmark": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.1.tgz",
+      "integrity": "sha512-DafPdNYFXoEhsSiR4O+dJ45UJBfDL4cBTks4B+agKiaWt7qjG0bIhg5xuCE0RqU71ikJcBIf4/sRHh9vYQVF8Q==",
+      "requires": {
+        "entities": "~1.1.1",
+        "mdurl": "~1.0.1",
+        "minimist": "~1.2.0",
+        "string.prototype.repeat": "^0.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        }
+      }
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -4738,8 +4756,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errno": {
       "version": "0.1.7",
@@ -6475,7 +6492,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7179,6 +7199,12 @@
           }
         }
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",
@@ -11004,6 +11030,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -14613,6 +14644,11 @@
           }
         }
       }
+    },
+    "string.prototype.repeat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/transferwise/styleguide-components",
   "dependencies": {
     "angular": "~1.5.10",
+    "commonmark": "^0.29.1",
     "jquery": "^3.4.1",
     "screenfull": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/demo.js
+++ b/src/demo.js
@@ -87,6 +87,7 @@ module.config(['$compileProvider', ($compileProvider) => {
       <li><a href="index.html#date-format">Date format</a></li>
       <li><a href="index.html#number-format">Number format</a></li>
       <li><a href="index.html#text-format">Text format</a></li>
+      <li><a href="index.html#markdown">Markdown</a></li>
     </ul>
 
     <h5>Layout</h5>

--- a/src/formatting/demo.html
+++ b/src/formatting/demo.html
@@ -10,5 +10,7 @@
     <tw-currency-format-docs locales="$ctrl.locales"></tw-currency-format-docs>
     <hr class="m-b-5" />
     <tw-date-format-docs locales="$ctrl.locales"></tw-date-format-docs>
+    <hr class="m-b-5" />
+    <tw-markdown-docs></tw-markdown-docs>
   </div>
 </div>

--- a/src/formatting/demo.js
+++ b/src/formatting/demo.js
@@ -5,12 +5,14 @@ import TextFormat from './text-format/text-format.demo.js';
 import DateFormat from './date-format/date-format.demo.js';
 import NumberFormat from './number-format/number-format.demo.js';
 import CurrencyFormat from './currency-format/currency-format.demo.js';
+import Markdown from './markdown/markdown.demo.js';
 
 export default angular.module('tw.styleguide.demo.formatting', [
   TextFormat,
   DateFormat,
   NumberFormat,
-  CurrencyFormat
+  CurrencyFormat,
+  Markdown
 ]).component('formattingDocs', {
   bindings: {
     model: '=',

--- a/src/formatting/index.js
+++ b/src/formatting/index.js
@@ -4,10 +4,12 @@ import TextFormat from './text-format';
 import DateFormat from './date-format';
 import NumberFormat from './number-format';
 import CurrencyFormat from './currency-format';
+import Markdown from './markdown';
 
 export default angular.module('tw.styleguide.formatting', [
   TextFormat,
   DateFormat,
   NumberFormat,
-  CurrencyFormat
+  CurrencyFormat,
+  Markdown,
 ]).name;

--- a/src/formatting/markdown/index.js
+++ b/src/formatting/markdown/index.js
@@ -1,0 +1,7 @@
+import angular from 'angular';
+import MarkdownComponent from './markdown.component';
+
+export default angular
+  .module('tw.styleguide.formatting.markdown', [])
+  .component('twMarkdown', MarkdownComponent)
+  .name;

--- a/src/formatting/markdown/markdown.component.js
+++ b/src/formatting/markdown/markdown.component.js
@@ -1,0 +1,12 @@
+import template from './markdown.html';
+import controller from './markdown.controller.js';
+
+const Markdown = {
+  controller,
+  template,
+  bindings: {
+    markdown: '<',
+  }
+};
+
+export default Markdown;

--- a/src/formatting/markdown/markdown.controller.js
+++ b/src/formatting/markdown/markdown.controller.js
@@ -1,0 +1,36 @@
+import commonmark from 'commonmark';
+
+class MarkdownController {
+  constructor($element, $sce) {
+    this.$element = $element;
+    this.$sce = $sce;
+
+    this.reader = new commonmark.Parser();
+    this.writer = new commonmark.HtmlRenderer({ safe: true });
+  }
+
+  $onChanges(changes) {
+    if (changes.markdown) {
+      this.render();
+    }
+  }
+
+  render() {
+    if (!this.markdown) {
+      this.html = '';
+      return;
+    }
+    const parsed = this.reader.parse(this.markdown);
+    const result = this.writer.render(parsed);
+
+    this.html = this.$sce.trustAsHtml(result);
+  }
+}
+
+
+MarkdownController.$inject = [
+  '$element',
+  '$sce',
+];
+
+export default MarkdownController;

--- a/src/formatting/markdown/markdown.demo.html
+++ b/src/formatting/markdown/markdown.demo.html
@@ -5,7 +5,7 @@
 </p>
 <div class="row m-b-3">
   <div class="col-md-6">
-    <tw-markdown markdown="$ctrl.markdown" />
+    <tw-markdown markdown="$ctrl.markdown"></tw-markdown>
     <pre>
     &lt;tw-markdown
       markdown='{{ $ctrl.markdown }}'&gt;

--- a/src/formatting/markdown/markdown.demo.html
+++ b/src/formatting/markdown/markdown.demo.html
@@ -1,0 +1,29 @@
+<h4 id="markdown">Markdown</h4>
+<p>
+  <code>twMarkdown</code> is a component for rendering markdown. It takes the supplied markdown and renders it as HTML using the Commonmark library.
+  Any raw HTML provided within the markdown and unsafe URL strings are automatically removed by the Commonmark library.
+</p>
+<div class="row m-b-3">
+  <div class="col-md-6">
+    <tw-markdown markdown="$ctrl.markdown" />
+    <pre>
+    &lt;tw-markdown
+      markdown='{{ $ctrl.markdown }}'&gt;
+    &lt;/tw-markdown&gt;
+    </pre>
+  </div>
+  <div class="col-md-6">
+    <div class="well">
+      <h5 class="page-header">Edit configuration</h5>
+        <div class="form-group">
+          <label class="control-label">Markdown</label>
+          <textarea
+            class="form-control"
+            ng-model="$ctrl.markdown"
+            ng-model-options="{ debounce: 300 }"
+            ng-style="{ 'height': '400px' }">
+          </textarea>
+        </div>
+    </div>
+  </div>
+</div>

--- a/src/formatting/markdown/markdown.demo.js
+++ b/src/formatting/markdown/markdown.demo.js
@@ -1,0 +1,23 @@
+import angular from 'angular';
+import template from './markdown.demo.html';
+
+export default angular
+  .module('tw.styleguide.demo.formatting.markdown', [])
+  .component('twMarkdownDocs', {
+    bindings: {
+      markdown: '<'
+    },
+    controller() {
+      // eslint-disable-next-line no-multi-str
+      this.markdown = `# This is a heading
+## This is a sub heading 
+* item 1 
+* item 2
+1. item 1
+2. item 2
+
+**hello**  *world*
+<div>this is a div and it should NOT be rendered</div>`;
+    },
+    template
+  }).name;

--- a/src/formatting/markdown/markdown.html
+++ b/src/formatting/markdown/markdown.html
@@ -1,0 +1,1 @@
+<div ng-bind-html="$ctrl.html"></div>

--- a/src/formatting/markdown/markdown.spec.js
+++ b/src/formatting/markdown/markdown.spec.js
@@ -1,0 +1,90 @@
+'use strict';
+
+describe('Markdown component, ', function() {
+  let $compile;
+  let $rootScope;
+  let $scope;
+
+  beforeEach(function() {
+    angular.mock.module('tw.styleguide.formatting.markdown');
+
+    angular.mock.inject(function($injector) {
+      $rootScope = $injector.get('$rootScope');
+      $compile = $injector.get('$compile');
+      $scope = $rootScope.$new();
+      
+    });
+  });
+
+  describe('Given markdown is provided', () => {
+    let template;
+
+    beforeEach(() => {
+      $scope.markdown = "# this is a heading";
+
+      template =
+      " \
+          <tw-markdown \
+              markdown='markdown'> \
+          </tw-markdown>";
+    });
+
+
+    it('renders the markdown as HTML', () => {
+      const element = getCompiledDirectiveElement($scope, template);
+
+      expect(element.querySelector('h1').textContent).toBe('this is a heading');
+    });
+  });
+
+  describe('Given markdown has raw HTML', () => {
+    let template;
+
+    beforeEach(() => {
+      $scope.markdown = `## subheading
+<img src='dodgyimagesrc' />`;
+
+      template =
+      " \
+          <tw-markdown \
+              markdown='markdown'> \
+          </tw-markdown>";
+    });
+
+    it('should NOT render the raw HTML', () => {
+      const element = getCompiledDirectiveElement($scope, template);
+
+        expect(element.querySelector('h2').textContent).toBe('subheading')
+      expect(element.querySelector('img')).toBeFalsy();
+    });
+  });
+
+  describe('Given markdown is NOT provided', () => {
+    let template;
+
+    beforeEach(() => {
+        template =
+        " \
+            <tw-markdown> \
+            </tw-markdown>";
+    });
+
+    it('should render nothing', () => {
+      const element = getCompiledDirectiveElement($scope, template);
+
+      expect(element.textContent).toBe('');
+    });
+  });
+
+  
+
+  function getCompiledDirectiveElement($scope, template) {
+    const element = angular.element(template);
+    
+    angular.element(document.body).append(element);
+    const compiledElement = $compile(element)($scope);
+
+    $scope.$digest();
+    return compiledElement[0];
+  }
+});


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
For EDD source of funds question we want to display two bullet pointed lists to the user. This currently isn't possible so a markdown component is needed

## Changes
introduces a markdown component

## Considerations
- still need to confirm mobile capacity for markdown implementation in v2.
- need to confirm which markdown features will be allowed in v3.

## Screenshots/GIFs
<img width="816" alt="Screenshot 2020-04-08 at 16 21 22" src="https://user-images.githubusercontent.com/57909099/78802341-9e4b5500-79b5-11ea-9492-d411d4b7618c.png">

## Checklist

- [X] All changes are covered by tests