### PR TITLE
AT-1340 Fix async validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.4.2
+## Fixes bug where validationMessages were not showing correctly in upload
+Error was not correctly passed to onPersistAsyncFailure method and read correctly if been via http interceptor.
+This PR corrects how error is sent and checked.
+
 # v5.4.1
 ## Readme update only, for advice on running tests on Ubuntu 16.04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/field/field.controller.js
+++ b/src/forms/field/field.controller.js
@@ -57,14 +57,14 @@ class FieldController {
       this.uploadOptions = {};
     }
 
-    if (response.data) {
-      // When we do id pre eval, we get error messages and validations back in
-      // the response, extract them and pass back to be shown in the upload.
-      this.extractErrors(response.data);
-    } else if (response.originalData) {
+    if (response.originalData) {
       // frontend-common has an interceptor that sometimes changes the response
       // format, moving the response data under a new key 'originalData'
       this.extractErrors(response.originalData);
+    } else if (response.data) {
+      // When we do id pre eval, we get error messages and validations back in
+      // the response, extract them and pass back to be shown in the upload.
+      this.extractErrors(response.data);
     }
   }
 
@@ -75,7 +75,8 @@ class FieldController {
     }
 
     if (Array.isArray(data.errors)) {
-      this.uploadOptions.validationMessages = data.errors.map(error => error.message);
+      // Only show the first two validation messages
+      this.uploadOptions.validationMessages = data.errors.map(error => error.message).slice(0, 2);
     }
   }
 

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -367,7 +367,7 @@ describe('Field', function() {
       expect(FormControl.bindings.uploadOptions.validationMessages).toEqual(['Too blurry']);
     });
 
-    describe('and when error has been handed by http interceptor', function() {
+    describe('and when error has been handled by http interceptor', function() {
       beforeEach(function() {
         FormControl.bindings.onAsyncFailure({
           response: {

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -366,6 +366,24 @@ describe('Field', function() {
       expect(FormControl.bindings.uploadOptions.failureText).toBe('My error');
       expect(FormControl.bindings.uploadOptions.validationMessages).toEqual(['Too blurry']);
     });
+
+    describe('and when error has been handed by http interceptor', function() {
+      beforeEach(function() {
+        FormControl.bindings.onAsyncFailure({
+          response: {
+            data: {},
+            originalData: {
+              message: 'My error',
+              errors: [{message: 'Too blurry'}]
+            }
+          }
+        });
+      });
+      it('should extract the error message and pass it back to the form control', function() {
+        expect(FormControl.bindings.uploadOptions.failureText).toBe('My error');
+        expect(FormControl.bindings.uploadOptions.validationMessages).toEqual(['Too blurry']);
+      });
+    })
   });
 
   describe('when the FormControl triggers onAsyncSuccess', function() {

--- a/src/forms/upload/upload.controller.js
+++ b/src/forms/upload/upload.controller.js
@@ -104,7 +104,7 @@ class UploadController {
 
   onProcessFailure(error) {
     if (this.onFailure) {
-      this.onFailure({ error });
+      this.onFailure(error);
     }
   }
 }

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -29,7 +29,7 @@
     ></tw-upload-capture>
   </div>
 
-  <div class="droppable-processing-card droppable-card"
+  <div class="droppable-processing-card droppable-card droppable-card--wider"
     aria-hidden="{{!$ctrl.isProcessing}}">
     <tw-upload-processing
       name="$ctrl.name"

--- a/src/forms/upload/upload.less
+++ b/src/forms/upload/upload.less
@@ -22,6 +22,11 @@ div.transparent-area {
     position: relative;
 }
 
+.droppable > .droppable-card--wider {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
 @media (min-width: 576px) {
     p.first-error {
         min-height:72px;


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
When upload component is used with persistAsync. The API returns error messaging, with a message and validation messages. These however were not being shown at all within the component.

## Changes
<!-- what this PR does -->
- Correctly passes up the error to the field component. 
- Check for `originalData` first as both `originalData` and `data` can exist where `data` is an object of various functions created by the http interceptor.
- Changes styling of processing card to allow wider content area to accommodate for validation messages
- Limits validation messages to two to avoid overspilling content.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before
<img width="375" alt="Screenshot 2020-04-14 at 17 22 01" src="https://user-images.githubusercontent.com/15638344/79251680-62facb80-7e78-11ea-922f-d05b57197d20.png">

### After getting error to show
<img width="389" alt="Screenshot 2020-04-14 at 15 31 42" src="https://user-images.githubusercontent.com/15638344/79251764-8160c700-7e78-11ea-9068-7cda5b714d73.png">

### After limiting to two and creating more space (final)
<img width="384" alt="Screenshot 2020-04-14 at 17 21 15" src="https://user-images.githubusercontent.com/15638344/79251798-9178a680-7e78-11ea-914f-9299b9fd1543.png">


## Checklist

- [x] All changes are covered by tests