### PR TITLE
Fix ng-style widths not working sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.5.1
+## Fix for v5.5.0: widths sometimes not calculating properly in ng-style for camera
+
 # v5.5.0
 ## Refactors and fixes assorted bugs with the camera upload component
 Most importantly, the camera component will now save images based on the camera resolution, not screen resolution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/camera-capture/camera-capture.html
+++ b/src/forms/upload/camera-capture/camera-capture.html
@@ -1,7 +1,7 @@
 <div id="camera" ng-class="{translucent: $ctrl.mode === 'loading'}">
   <video id="cameraViewfinder" class="fixed w-100 h-100" ng-show="$ctrl.mode === 'capture'" ng-class="{mirrored: ($ctrl.direction || '').toLowerCase() === 'user'}" playsinline></video>
-  <div id="cameraViewfinderOverlay" ng-if="$ctrl.overlay && $ctrl.mode === 'capture'" ng-class="{mirrored: ($ctrl.direction || '').toLowerCase() === 'user'}" ng-style="{'background-image': 'url(' + $ctrl.overlay + ')', width: $ctrl.overlaySquareLength, height: $ctrl.overlaySquareLength}"></div>
-  <canvas id="cameraSensor" ng-show="$ctrl.mode === 'confirm'" ng-style="{width: $ctrl.sensorWidth}"></canvas>
+  <div id="cameraViewfinderOverlay" ng-if="$ctrl.overlay && $ctrl.mode === 'capture'" ng-class="{mirrored: ($ctrl.direction || '').toLowerCase() === 'user'}" ng-style="{'background-image': 'url(' + $ctrl.overlay + ')', width: $ctrl.overlaySquareLength + 'px', height: $ctrl.overlaySquareLength + 'px'}"></div>
+  <canvas id="cameraSensor" ng-show="$ctrl.mode === 'confirm'" ng-style="{width: $ctrl.sensorWidth + 'px'}"></canvas>
 
   <label class="fixed-bottom camera-ctrl-bar">
     <span class="camera-ctrl-box-small">


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
Fixes a bug discovered with the recently refactored camera component introduced in https://github.com/transferwise/styleguide-components/pull/293 (v5.5.0).

## Changes
Fix the width expression in `ng-style` attributes on the camera sub-components, so that they'll calculate validly.

## Considerations
This bug doesn't occur when running styleguide-components locally, but for whatever environmental reason, it won't work in `standalone-verification-app` unless the `+ 'px'` units are added. `+ ''` didn't work either, so it's not a numbers-vs-strings thing.

## Checklist

- [ ] All changes are covered by tests