### PR TITLE
ASIA-3207: Try changing the requested width/height of webcam requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.6.1
+## Change requested size of images uploaded through the camera component
+
 # v5.6.0
 ## Add checkbox-group component
 Add checkbox-group component and support checkbox control for DF

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -151,8 +151,8 @@ class CameraCaptureController {
 
       this.cameraConstraints = {
         video: {
-          width: { ideal: 2300 },
-          height: { ideal: 2300 },
+          width: { ideal: 1600 },
+          height: { ideal: 1600 },
           facingMode: {
             ideal: this.direction.toLowerCase()
           }


### PR DESCRIPTION
_(not guaranteed to fix anything, but it's a very cheap change, and it affects only Japan verification at this moment)_

## Context
Japan verification (the only users of the live camera component at the moment) have this very weird occasional JPG artifacting/corruption issue with users, where the JPGs uploaded will be split into 4 or 8 disjoint layers, with a discoloured band at the bottom (examples viewable in the ticket, if you have verification file access). This issue seems to have surfaced after https://github.com/transferwise/styleguide-components/pull/293/files.

Something in the capture pipeline is definitely broken, but we're not sure what (we can't reproduce it). But we've observed that so far all the broken images are 2300x2300px (which is the size we optionally request for (we arbitrarily chose 2300) ever since the previous PR). Furthermore the fact that the number of layers is either 4 or 8 (and equally sized) makes it feel like its some kind of rescaling/odd-division error.

The size we're requesting is the biggest suspect for now, so we'd like to change the size to a "more divisible" 1600px, and see whether that ends up having any effect in the wild. 

## Changes
Change the requested camera size from 2300x2300 to 1600x1600.

## Considerations
1600px should be enough pixels for KYC Ops, they've verified with lower resolutions before.

- [ ] All changes are covered by tests