### PR TITLE
Implement camera-permissions error messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.6.3
+## Fix camera component to show an optional error message if camera permissions were rejected
+
 # v5.6.2
 ## Fix camera component to accept an overlay outline according to the updated camera guidelines specification
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/form-control/form-control.html
+++ b/src/forms/form-control/form-control.html
@@ -80,6 +80,8 @@
       processing-text="{{ $ctrl.uploadOptions.processingText }}"
       success-text="{{ $ctrl.uploadOptions.successText }}"
       failure-text="{{ $ctrl.uploadOptions.failureText }}"
+      no-camera-text="{{ $ctrl.uploadOptions.noCameraText }}"
+      no-camera-message="{{ $ctrl.uploadOptions.noCameraMessage }}"
       validation-messages="$ctrl.uploadOptions.validationMessages"
       view-image-text="{{$ctrl.uploadOptions.viewImageText}}"
       too-large-message="{{$ctrl.uploadTooLargeMessage}}"

--- a/src/forms/upload/camera-capture/camera-capture.component.js
+++ b/src/forms/upload/camera-capture/camera-capture.component.js
@@ -10,6 +10,7 @@ const CameraCapture = {
 
     onCancel: '&',
     onCapture: '&',
+    onError: '&',
 
     /**
      * Need this parameter to skip user interaction

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -32,8 +32,14 @@ class CameraCaptureController {
     this.overlaySquareLength = 0;
     this.sensorWidth = 0;
 
-    if (!this.hasGetUserMedia()) {
-      this.$log.warn('getUserMedia() is not supported by your browser');
+    if (this.$window.navigator.mediaDevices === undefined) {
+      this.$log.error('navigator.mediaDevices not accessible on this browser');
+      this.onError();
+      return;
+    }
+
+    if (this.$window.navigator.mediaDevices.getUserMedia === undefined) {
+      this.$log.error('mediaDevices.getUserMedia is not implemented on this browser');
       this.onError();
       return;
     }
@@ -217,10 +223,6 @@ class CameraCaptureController {
       }
       $ngModel.$setViewValue(value);
     }
-  }
-
-  hasGetUserMedia() {
-    return !!((this.$window.navigator.mediaDevices || {}).getUserMedia);
   }
 
   findContainer() { return this.$element[0].querySelector('#camera'); }

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -33,8 +33,9 @@ class CameraCaptureController {
     this.sensorWidth = 0;
 
     if (!this.hasGetUserMedia()) {
-      // TODO: haoyuan how to handle get user media not being available?
       this.$log.warn('getUserMedia() is not supported by your browser');
+      this.onError();
+      return;
     }
 
     // lock document scroll.
@@ -106,7 +107,8 @@ class CameraCaptureController {
       }).catch((err) => {
         // TODO haoyuan : Should somehow ask user to refresh page to reaquire permission
         this.$log.error(err);
-        this.onCancelBtnClick();
+        this.closeVideoStream();
+        this.onError();
       });
   }
 

--- a/src/forms/upload/camera-capture/camera-capture.spec.js
+++ b/src/forms/upload/camera-capture/camera-capture.spec.js
@@ -324,3 +324,5 @@ describe('Given a camera capture component', () => {
     return component.querySelector('.camera-ctrl-btn-cancel');
   }
 });
+
+// should call onError callback on an error.

--- a/src/forms/upload/camera-capture/camera-capture.spec.js
+++ b/src/forms/upload/camera-capture/camera-capture.spec.js
@@ -18,6 +18,7 @@ describe('Given a camera capture component', () => {
     guidelines='guidelines' \
     on-cancel='onCancel()' \
     on-capture='onCapture(file)' \
+    on-error='onError()' \
   </tw-camera-capture>";
 
   beforeEach(function() {
@@ -49,6 +50,7 @@ describe('Given a camera capture component', () => {
 
     $scope.onCancel = jest.fn();
     $scope.onCapture = jest.fn();
+    $scope.onError = jest.fn();
   });
 
   describe('when initialising', () => {
@@ -74,6 +76,33 @@ describe('Given a camera capture component', () => {
       compileComponent();
 
       expect(screenfull.request).toHaveBeenCalledTimes(1);
+    });
+
+    describe('if camera is not available', () => {
+      describe('because navigator.mediaDevices is undefined (e.g. insecure browser context)', () => {
+        beforeEach(() => {
+          delete $window.navigator.mediaDevices;
+          compileComponent();
+        });
+
+        it('should trigger the bound onError callback', () => {
+          expect($scope.onError).toHaveBeenCalledTimes(1);
+        });
+      })
+
+      describe('because mediaDevices.getUserMedia() rejects (e.g. user refused permission)', () => {
+        beforeEach(() => {
+          $window.navigator.mediaDevices = {
+            getUserMedia: jest.fn($q.reject),
+          };
+          compileComponent();
+        });
+
+        it('should trigger the bound onError callback', () => {
+          expect($scope.onError).toHaveBeenCalledTimes(1);
+        });
+      });
+
     });
 
     describe('if fullscreen switching succeeds', () => {

--- a/src/forms/upload/capture-card/capture-card.component.js
+++ b/src/forms/upload/capture-card/capture-card.component.js
@@ -13,6 +13,8 @@ const CaptureCard = {
     placeholder: '<',
     inputFile: '<',
     helpImage: '<',
+    noCameraText: '<',
+    noCameraMessage: '<',
 
     isLiveCameraUpload: '<',
     cameraGuidelines: '<',

--- a/src/forms/upload/capture-card/capture-card.controller.js
+++ b/src/forms/upload/capture-card/capture-card.controller.js
@@ -2,6 +2,7 @@ class Controller {
   constructor($element) {
     this.$element = $element;
     this.showLiveCaptureScreen = false;
+    this.cameraFailed = false;
   }
 
   $onChanges(changes) {
@@ -14,6 +15,11 @@ class Controller {
     this.showLiveCaptureScreen = false;
   }
 
+  onCameraError() {
+    this.showLiveCaptureScreen = false;
+    this.cameraFailed = true;
+  }
+
   onCameraCapture(file) {
     this.showLiveCaptureScreen = false;
     this.onFileCapture({ file });
@@ -21,6 +27,7 @@ class Controller {
 
   onCameraButtonClick() {
     this.showLiveCaptureScreen = true;
+    this.cameraFailed = false;
   }
 
   onButtonCapture(files) {

--- a/src/forms/upload/capture-card/capture-card.html
+++ b/src/forms/upload/capture-card/capture-card.html
@@ -1,24 +1,38 @@
 <div class="droppable-card-content">
-  <!-- Display illustration as image or icon -->
-  <div class="m-b-2">
-    <img
-      ng-show="$ctrl.helpImage"
-      ng-src="{{$ctrl.helpImage}}"
-      alt="{{$ctrl.label}}"
-      class="thumbnail text-xs-center" />
-    <span ng-show="!$ctrl.helpImage"
-      class="icon icon-{{$ctrl.viewIcon}} icon-xxl"></span>
+  <div ng-if="!$ctrl.cameraFailed">
+    <!-- Display illustration as image or icon -->
+    <div class="m-b-2">
+      <img
+        ng-show="$ctrl.helpImage"
+        ng-src="{{$ctrl.helpImage}}"
+        alt="{{$ctrl.label}}"
+        class="thumbnail text-xs-center" />
+      <span ng-show="!$ctrl.helpImage"
+        class="icon icon-{{$ctrl.viewIcon}} icon-xxl"></span>
+    </div>
+
+    <!-- control label -->
+    <h4 class="m-b-1" ng-if="$ctrl.label || $ctrl.description">
+      {{$ctrl.label || $ctrl.description}}
+    </h4>
+
+    <!-- placeholder instructions -->
+    <p class="m-b-2" ng-if="$ctrl.placeholder || $ctrl.instructions">
+      {{$ctrl.placeholder || $ctrl.instructions}}
+    </p>
   </div>
 
-  <!-- control label -->
-  <h4 class="m-b-1" ng-if="$ctrl.label || $ctrl.description">
-    {{$ctrl.label || $ctrl.description}}
-  </h4>
+  <div ng-if="$ctrl.cameraFailed">
+    <div class="m-b-2">
+      <tw-process
+        state='-1'
+        size='sm'
+      ></tw-process>
+    </div>
 
-  <!-- placeholder instructions -->
-  <p class="m-b-2" ng-if="$ctrl.placeholder || $ctrl.instructions">
-    {{$ctrl.placeholder || $ctrl.instructions}}
-  </p>
+    <h4 class="m-b-1" ng-if="$ctrl.noCameraText">{{$ctrl.noCameraText}}</h4>
+    <p class="m-b-2" ng-if="$ctrl.noCameraMessage">{{$ctrl.noCameraMessage}}</p>
+  </div>
 
   <!-- file upload -->
   <tw-upload-button
@@ -43,6 +57,7 @@
     ng-if="$ctrl.isLiveCameraUpload && $ctrl.showLiveCaptureScreen"
     guidelines="$ctrl.cameraGuidelines"
     on-cancel="$ctrl.onCameraCancel()"
-    on-capture="$ctrl.onCameraCapture(file)">
+    on-capture="$ctrl.onCameraCapture(file)"
+    on-error="$ctrl.onCameraError()">
   </tw-camera-capture>
 </div>

--- a/src/forms/upload/upload.component.js
+++ b/src/forms/upload/upload.component.js
@@ -22,6 +22,8 @@ const Upload = {
     processingText: '@', // Text shown while processing/uploading
     successText: '@', // Text after upload is successful, shown quite briefly before preview
     failureText: '@',
+    noCameraText: '@',
+    noCameraMessage: '@',
 
     tooLargeMessage: '@',
     // wrongTypeMessage: '@',

--- a/src/forms/upload/upload.demo.html
+++ b/src/forms/upload/upload.demo.html
@@ -66,6 +66,8 @@
         processing-text="{{$ctrl.processingText}}"
         success-text="{{$ctrl.successText}}"
         failure-text="{{$ctrl.failureText}}"
+        no-camera-text="{{$ctrl.noCameraText}}"
+        no-camera-message="{{$ctrl.noCameraMessage}}"
 
         on-start="$ctrl.onStart"
         on-success="$ctrl.onSuccess"
@@ -96,7 +98,9 @@
   dropping-text="{{$ctrl.droppingText}}"</span><span ng-if="$ctrl.processingText">
   processing-text="{{$ctrl.processingText}}"</span><span ng-if="$ctrl.successText">
   success-text="{{$ctrl.successText}}"</span><span ng-if="$ctrl.failureText">
-  failure-text="{{$ctrl.failureText}}"</span><span ng-if="$ctrl.httpOptions">
+  failure-text="{{$ctrl.failureText}}"</span><span ng-if="$ctrl.noCameraText">
+  no-camera-text="{{$ctrl.noCameraText}}"</span><span ng-if="$ctrl.noCameraMessage">
+  no-camera-message="{{$ctrl.noCameraMessage}}"</span><span ng-if="$ctrl.httpOptions">
   http-options="{{$ctrl.httpOptions}}"</span><span ng-if="$ctrl.errorMessage">
   error-message="{{$ctrl.errorMessage}}"</span>
   on-start="$ctrl.onStart"
@@ -221,6 +225,18 @@
           Failure text
         </label>
         <input type="text" class="form-control" ng-model="$ctrl.failureText" />
+      </div>
+      <div class="form-group">
+        <label class="control-label">
+          No-camera text
+        </label>
+        <input type="text" class="form-control" ng-model="$ctrl.noCameraText" />
+      </div>
+      <div class="form-group">
+        <label class="control-label">
+          No-camera message
+        </label>
+        <input type="text" class="form-control" ng-model="$ctrl.noCameraMessage" />
       </div>
 
       <div class="form-group">

--- a/src/forms/upload/upload.demo.js
+++ b/src/forms/upload/upload.demo.js
@@ -70,6 +70,8 @@ function controller($scope) {
   $ctrl.droppingText = 'Drop file to begin...';
   $ctrl.successText = 'Upload complete!';
   $ctrl.failureText = 'Upload failed!';
+  $ctrl.noCameraText = 'Couldn\'t detect your camera';
+  $ctrl.noCameraMessage = 'Please enable camera permissions, try a different browser, or use a different device.';
 
   this.makeFancy = () => {};
 

--- a/src/forms/upload/upload.html
+++ b/src/forms/upload/upload.html
@@ -20,6 +20,8 @@
       input-file="$ctrl.inputFile"
       help-image="$ctrl.helpImage"
       button-text="$ctrl.buttonText"
+      no-camera-text="$ctrl.noCameraText"
+      no-camera-message="$ctrl.noCameraMessage"
       ng-disabled="$ctrl.ngDisabled"
       placeholder="$ctrl.placeholder || $ctrl.description"
       is-live-camera-upload="$ctrl.isLiveCameraUpload"


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
When trying to invoke the live camera for Japan verification, the camera currently doesn't handle the error of the camera being unavailable (due to permissions issues etc.). As such it currently freezes on its translucent black loading screen.

## Changes
This PR adds error messaging in the event of an inaccessible-camera case. The messages will be passed in externally by consumers (e.g. for Dynamic Forms, the 2 new messages will be passed in through `upload-options`).

## Considerations
A bit of discussion: https://transferwise.slack.com/archives/C2SGDKP4Y/p1587966855264000?thread_ts=1587966855.264000

## Original Pull Request (for version bumps)
Nil

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

![Screenshot from 2020-05-29 12-10-26](https://user-images.githubusercontent.com/2840821/83221038-4e179480-a1a7-11ea-92e7-29f2a55b6810.png)

### After

![Screenshot from 2020-05-29 12-30-22](https://user-images.githubusercontent.com/2840821/83221648-f11cde00-a1a8-11ea-8f0c-df2d22ff01d5.png)

## Checklist

- [x] All changes are covered by tests