### PR TITLE
ASIA-3209: Default to a camera icon instead of an upload icon for the camera upload component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.6.4
+## Tweak camera component image and button to default to camera icons instead of upload icons
+
 # v5.6.3
 ## Fix camera component to show an optional error message if camera permissions were rejected
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/camera-button/camera-button.html
+++ b/src/forms/upload/camera-button/camera-button.html
@@ -2,5 +2,5 @@
   ng-click="$ctrl.onButtonClick()"
   ng-class="{ 'disabled': $ctrl.disabled }">
   <span ng-if="$ctrl.label" ng-bind="$ctrl.label"></span>
-  <span ng-if="!$ctrl.label" class="icon icon-upload m-r-0"></span>
+  <span ng-if="!$ctrl.label" class="icon icon-camera m-r-0"></span>
 </label>

--- a/src/forms/upload/capture-card/capture-card.controller.js
+++ b/src/forms/upload/capture-card/capture-card.controller.js
@@ -6,8 +6,12 @@ class Controller {
   }
 
   $onChanges(changes) {
-    if (changes.icon) {
-      this.viewIcon = changes.icon.currentValue ? changes.icon.currentValue : 'upload';
+    if (changes.icon || changes.isLiveCameraUpload) {
+      if ((changes.icon || {}).currentValue) {
+        this.viewIcon = changes.icon.currentValue;
+      } else {
+        this.viewIcon = (changes.isLiveCameraUpload || {}).currentValue ? 'camera' : 'upload';
+      }
     }
   }
 


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
It's a bit weird that the default icon for a camera-capture component is the upload icon, when uploading from disk is impossible.

## Changes
Change the camera-capture component to show camera icons instead of upload icons.

## Considerations
If the user wants to override the helper icon and button text, they still can. This just changes the default that's shown if the user didn't do any overriding.

## Screenshots/GIFs

### Before

![Screenshot from 2020-06-01 12-36-44](https://user-images.githubusercontent.com/2840821/83376563-376e7900-a405-11ea-8daf-2f3790e22c3b.png)

### After

![Screenshot from 2020-06-01 12-35-51](https://user-images.githubusercontent.com/2840821/83376573-405f4a80-a405-11ea-8d2b-29f826a494be.png)

### Others

Did an eyeball check that non-camera uploads remain unaffected, and continue to show an upload icon by default:

![Screenshot from 2020-06-01 12-35-23](https://user-images.githubusercontent.com/2840821/83376609-65ec5400-a405-11ea-8d3e-30a6b6991c14.png)


## Checklist

- [ ] All changes are covered by tests