### PR TITLE
Update Australian External Territories entry in telephone countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.6.5
+## Update Australian External Territories country code
+
 # v5.6.4
 ## Tweak camera component image and button to default to camera icons instead of upload icons
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/telephone/countries.json
+++ b/src/forms/telephone/countries.json
@@ -76,7 +76,7 @@
 }, {
 	"name": "Australian Antarctic Territory",
 	"iso2": "AQ",
-	"iso3": "AUS",
+	"iso3": "ATA",
 	"phone": "+672"
 }, {
 	"name": "Austria",

--- a/src/forms/telephone/countries.json
+++ b/src/forms/telephone/countries.json
@@ -74,8 +74,8 @@
 	"iso3": "AUS",
 	"phone": "+61"
 }, {
-	"name": "Australian External Territories",
-	"iso2": "AU",
+	"name": "Australian Antarctic Territory",
+	"iso2": "AQ",
 	"iso3": "AUS",
 	"phone": "+672"
 }, {

--- a/src/services/locale/locale.spec.js
+++ b/src/services/locale/locale.spec.js
@@ -37,10 +37,10 @@ describe('TwDateService test', function() {
 
   describe('when setting the locale with uncapitalised country', function() {
     beforeEach(function() {
-      LocaleService.setCurrent('fr-fr');
+      LocaleService.setCurrent('en-au');
     });
     it('should change the case', function () {
-      expect(LocaleService.getCurrent()).toBe('fr-FR');
+      expect(LocaleService.getCurrent()).toBe('en-AU');
     });
   });
 


### PR DESCRIPTION
## Context

https://transferwise.atlassian.net/browse/SEND-737

When creating a profile in the transferFlow we pass in the users locale to twTelephone based on the country they registered with. In the case of Australia, this is `en-AU`, which currently prefills the telephone input with `+672` - the phone code for Antarctica. 

This is because it's getting multiple hits for the `AU` `iso2` lookup it's doing in `countries.json`, and it is (for whatever reason) preferring whichever phone code is longer https://github.com/transferwise/styleguide-components/blob/master/src/forms/telephone/telephone.controller.js#L143-L149

## Changes

Updates the Australian External Territories entry in `countries.json` to use the Antarctica iso2 code, supported by this note in Wikipedia on Australias external territories https://en.wikipedia.org/wiki/ISO_3166-2:AU#External_territories

![image](https://user-images.githubusercontent.com/52408757/84683971-e2b41d80-af2f-11ea-8a54-66110f8d94e9.png)


## Considerations

- Not an expert on the ISO spec and found it very hard to find a legitimate source of truth for this country code as it's a bit of an outlier and isn't explicitly mentioned on their website under AU or AQ: https://www.iso.org/obp/ui/#iso:code:3166:AQ https://www.iso.org/obp/ui/#iso:code:3166:AU
- If we do go forward with updating the iso2 to `AQ` instead of `AU`, does it follow that we should update the iso3 to `ATA` instead of `AUS`?
- My test only implicitly covers this issue, is it worth adding an explicit test for this use-case?

## Checklist

- [x] All changes are covered by tests