### PR TITLE
Make Fieldset remove invalid properties when it receives new fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v7.0.0
 ## Fieldsets now remove invalid properties from the model when receiving new fields
-If the set of fields is updated, any properties of the model that are not reflected in the new set of fields will be removed.
+BREAKING: If the set of fields is updated, any properties of the model that are not reflected in the new set of fields will be removed.  This could be a breaking change if a consumer relies on the fieldset leaving other properties of a model untouched.
 
 Alongside those changes we also improve the checkbox-group implementation to work with numeric enums as well as strings. The requirements service now better identifies checkbox-groups based on their data type, and we have improved the definition list to show the labels for the enums rather than the raw values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v7.0.0
+## Fieldsets now remove invalid properties from the model when receiving new fields
+If the set of fields is updated, any properties of the model that are not reflected in the new set of fields will be removed.
+
+Alongside those changes we also improve the checkbox-group implementation to work with numeric enums as well as strings. The requirements service now better identifies checkbox-groups based on their data type, and we have improved the definition list to show the labels for the enums rather than the raw values.
+
 # v6.1.0
 ## Support descriptions for radio/checkbox controls, change JSON schema validation approach
 Within the JSON schema dynamic forms we adopt an approach to validation that is more explicitly checking the broadcast values, rather than use the ngModel validation pipeline.  This brings us into line with the React implementation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/checkbox-group/checkbox-group.component.js
+++ b/src/forms/checkbox-group/checkbox-group.component.js
@@ -11,7 +11,7 @@ const Checkbox = {
   bindings: {
     name: '@',
     ngChange: '&',
-    ngModel: '=',
+    ngModel: '<',
     ngRequired: '<',
     ngDisabled: '<',
     options: '<',

--- a/src/forms/checkbox-group/checkbox-group.controller.js
+++ b/src/forms/checkbox-group/checkbox-group.controller.js
@@ -1,7 +1,7 @@
 
 class CheckboxGroupController {
   constructor($element, TwDomService) {
-    this.$ngModel = $element.controller('ngModel');
+    this.$ngModelController = $element.controller('ngModel');
 
     this.dom = TwDomService;
     this.$element = $element;
@@ -40,9 +40,9 @@ class CheckboxGroupController {
 
   onInternalModelChange() {
     this.internalModel = convertOptionsToModel(this.internalOptions);
-    this.$ngModel.$setViewValue(this.internalModel);
-    this.$ngModel.$setTouched();
-    this.$ngModel.$setDirty();
+    this.$ngModelController.$setViewValue(this.internalModel);
+    this.$ngModelController.$setTouched();
+    this.$ngModelController.$setDirty();
   }
 
   isCheckboxRequired() {
@@ -50,7 +50,7 @@ class CheckboxGroupController {
   }
 
   validate() {
-    if (!this.$ngModel.$touched) {
+    if (!this.$ngModelController.$touched) {
       return;
     }
 
@@ -61,12 +61,12 @@ class CheckboxGroupController {
     const isRequired = this.ngRequired;
 
     if (!isChecked && isRequired) {
-      this.$ngModel.$setValidity('required', false);
+      this.$ngModelController.$setValidity('required', false);
       if (formGroup) {
         formGroup.classList.add('has-error');
       }
     } else {
-      this.$ngModel.$setValidity('required', true);
+      this.$ngModelController.$setValidity('required', true);
       if (formGroup) {
         formGroup.classList.remove('has-error');
       }

--- a/src/forms/checkbox-group/checkbox-group.demo.html
+++ b/src/forms/checkbox-group/checkbox-group.demo.html
@@ -5,19 +5,16 @@
   <div class="col-md-6">
     <div class="form-group">
       <label class="control-label">
-        TW Checkbox Group
+        TW Checkbox Group<span ng-if="$ctrl.checkbox.required">*</span>
       </label>
       <div class="checkbox">
-          TW Checkbox<span ng-if="$ctrl.checkbox.required">*</span>
-          <tw-checkbox-group tw-validation
-            ng-model="$ctrl.model"
-            options="$ctrl.options"
-            ng-required="$ctrl.checkbox.required"
-            ng-disabled="$ctrl.checkbox.disabled"
-            ng-change="$ctrl.log('checkboxgroup change')">
-          </tw-checkbox-group>
-          
-
+        <tw-checkbox-group
+          ng-model="$ctrl.model"
+          options="$ctrl.options"
+          ng-required="$ctrl.checkbox.required"
+          ng-disabled="$ctrl.checkbox.disabled"
+          ng-change="$ctrl.log()">
+        </tw-checkbox-group>
       </div>
     </div>
 
@@ -27,8 +24,8 @@
   options="$ctrl.options"
   ng-required="$ctrl.checkbox.required"
   ng-disabled="$ctrl.checkbox.disabled"
-  ng-change="$ctrl.log('checkbox change')"</span>
-  tw-validation&gt;&lt;/tw-checkbox-group&gt;</pre>
+  ng-change="$ctrl.log('checkbox change')"
+&gt;&lt;/tw-checkbox-group&gt;</pre>
   </div>
   <div class="col-md-6">
     <div class="well">

--- a/src/forms/checkbox-group/checkbox-group.demo.js
+++ b/src/forms/checkbox-group/checkbox-group.demo.js
@@ -4,16 +4,19 @@ import template from './checkbox-group.demo.html';
 class CheckboxGroupController {
   constructor() {
     this.options = [{
-      value: '1',
+      value: 1,
       label: 'One'
     },
     {
-      value: '2',
+      value: 2,
       label: 'Two'
     }];
+
+    this.model = [];
   }
-  log(message) { // eslint-disable-line
-    console.log(message); // eslint-disable-line
+
+  log() { // eslint-disable-line
+    console.log('checkbox-group changed', this.model); // eslint-disable-line
   }
 }
 

--- a/src/forms/checkbox-group/checkbox-group.html
+++ b/src/forms/checkbox-group/checkbox-group.html
@@ -1,10 +1,11 @@
-<div ng-repeat="option in $ctrl.options" class="checkbox">
+<div ng-repeat="option in $ctrl.internalOptions" class="checkbox">
   <label>
-    <tw-checkbox 
+    <tw-checkbox
       name="{{$ctrl.name}}"
-      ng-model="$ctrl.internalModel[option.value]"
+      ng-model="option.selected"
       ng-disabled="$ctrl.ngDisabled"
-      ng-change="$ctrl.onInternalModelChange(option.value)"
+      ng-required="$ctrl.isCheckboxRequired()"
+      ng-change="$ctrl.onInternalModelChange(option)"
     ></tw-checkbox>
     {{option.label}}
   </label>

--- a/src/forms/checkbox-group/checkbox-group.spec.js
+++ b/src/forms/checkbox-group/checkbox-group.spec.js
@@ -32,7 +32,7 @@ describe('Checkbox Group', () => {
     $scope.name = 'myCheckboxGroup';
     $scope.ngDisabled = false;
     $scope.ngRequired = true;
-    $scope.options = [{value: 1, label: "test 1"}, {value: 2, label: "test 2"}];
+    $scope.options = [{value: 1, label: 'One'}, {value: 2, label: 'Two'}];
 
     template = getCompiledTemplateElement($scope);
     $element = template.find(COMPONENT_SELECTOR);
@@ -50,6 +50,12 @@ describe('Checkbox Group', () => {
       expect(getCheckBoxValue(checkbox1)).toBe(true);
       expect(getCheckBoxValue(checkbox2)).toBe(false);
     });
+
+    it('should render the correct labels', () => {
+      const [ label1, label2 ] = $element.find('label');
+      expect(label1.innerText.trim()).toBe('One');
+      expect(label2.innerText.trim()).toBe('Two');
+    });
   });
 
   describe('when the model that is passed in changes', () => {
@@ -60,6 +66,52 @@ describe('Checkbox Group', () => {
     it('should update the checkboxes to reflect the model', () => {
       expect(getCheckBoxValue(checkbox1)).toBe(false);
       expect(getCheckBoxValue(checkbox2)).toBe(true);
+    });
+  });
+
+  describe('when the options that are passed in change and the model is still valid', () => {
+    beforeEach(() => {
+      $scope.options = [{value: 1, label: 'One'}, {value: 3, label: 'Three'}];
+      $scope.$apply();
+      [ checkbox1, checkbox2 ] = $element.find(CHECKBOX_SELECTOR);
+    });
+
+    it('should update the labels', () => {
+      const [ label1, label2 ] = $element.find('label');
+      expect(label1.innerText.trim()).toBe('One');
+      expect(label2.innerText.trim()).toBe('Three');
+    });
+
+    it('should update the checkboxes to reflect the model', () => {
+      expect(getCheckBoxValue(checkbox1)).toBe(true);
+      expect(getCheckBoxValue(checkbox2)).toBe(false);
+    });
+
+    it('should maintain the model value', () => {
+      expect($scope.model).toEqual([1]);
+    });
+  });
+
+  describe('when the options that are passed in change and the model is no longer valid', () => {
+    beforeEach(() => {
+      $scope.options = [{value: 2, label: 'Two'}, {value: 3, label: 'Three'}];
+      $scope.$apply();
+      [ checkbox1, checkbox2 ] = $element.find(CHECKBOX_SELECTOR);
+    });
+
+    it('should update the labels', () => {
+      const [ label1, label2 ] = $element.find('label');
+      expect(label1.innerText.trim()).toBe('Two');
+      expect(label2.innerText.trim()).toBe('Three');
+    });
+
+    it('should update the checkboxes to reflect the model', () => {
+      expect(getCheckBoxValue(checkbox1)).toBe(false);
+      expect(getCheckBoxValue(checkbox2)).toBe(false);
+    });
+
+    it('should update the model value', () => {
+      expect($scope.model).toEqual([]);
     });
   });
 
@@ -81,8 +133,8 @@ describe('Checkbox Group', () => {
       $scope.$apply();
     });
     it('should pass "disabled" prop to checkboxes', () => {
-      expect(checkbox1.getAttribute('disabled')).toBe("disabled");
-      expect(checkbox2.getAttribute('disabled')).toBe("disabled");
+      expect(checkbox1.getAttribute('disabled')).toBe('disabled');
+      expect(checkbox2.getAttribute('disabled')).toBe('disabled');
     });
   });
 

--- a/src/forms/checkbox-group/checkbox-group.spec.js
+++ b/src/forms/checkbox-group/checkbox-group.spec.js
@@ -2,104 +2,106 @@
 
 import checkboxGroup from ".";
 
-describe('Checkbox Group', function() {
+describe('Checkbox Group', () => {
   var $compile,
     $rootScope,
     $scope,
-    $ngModel,
-    $timeout,
-    internalModel,
-    templateElement,
-    directiveElement,
-    button,
-    checkbox,
-    Checkbox;
+    template,
+    $element,
+    checkbox1,
+    checkbox2,
+    button1,
+    button2;
 
-  var DIRECTIVE_SELECTOR = 'tw-checkbox-group';
+  var COMPONENT_SELECTOR = 'tw-checkbox-group';
   var BUTTON_SELECTOR = 'button';
   var CHECKBOX_SELECTOR = "tw-checkbox";
-  
-  beforeEach(function() {
-    Checkbox = getMockComponent('twCheckbox');
 
+  beforeEach(() => {
     angular.mock.module('tw.styleguide.forms.checkbox');
     angular.mock.module('tw.styleguide.forms.checkbox-group');
-    
+
     angular.mock.inject(function($injector) {
       $rootScope = $injector.get('$rootScope');
       $compile = $injector.get('$compile');
-      $timeout = $injector.get('$timeout');
     });
 
     $scope = $rootScope.$new();
 
-    $scope.ngModel = null;
+    $scope.ngModel = [1];
     $scope.name = 'myCheckboxGroup';
     $scope.ngDisabled = false;
     $scope.ngRequired = true;
-    $scope.options = [{value: "1", label: "test 1"}, {value: "2", label: "test 2"}];
+    $scope.options = [{value: 1, label: "test 1"}, {value: 2, label: "test 2"}];
 
-    
-    templateElement = getCompiledTemplateElement($scope);
-    directiveElement = () => templateElement.find(DIRECTIVE_SELECTOR);
-    $ngModel = () => directiveElement().controller('ngModel');
-    internalModel = () => angular.element(directiveElement()).scope();
-    checkbox = () =>  directiveElement().find(CHECKBOX_SELECTOR);
-    button = () => directiveElement().find(BUTTON_SELECTOR);
+    template = getCompiledTemplateElement($scope);
+    $element = template.find(COMPONENT_SELECTOR);
+
+    [ checkbox1, checkbox2 ] = $element.find(CHECKBOX_SELECTOR);
+    [ button1, button2] = $element.find(BUTTON_SELECTOR);
   });
 
-  describe('init', function() {
-    it('should render checkboxes for all options', function() {
-      expect(checkbox().length).toBe(2);
+  describe('init', () => {
+    it('should render checkboxes for all options', () => {
+      expect($element.find(CHECKBOX_SELECTOR).length).toBe(2);
     });
 
-    it('should render correct initial value', function() {
-      $scope.ngModel = ["1"];
-      $scope.$apply()
-      
-      expect(getCheckBoxValue(checkbox()[0])).toBe(true);
-      expect(getCheckBoxValue(checkbox()[1])).toBeFalsy();
-      
-      $scope.ngModel = ["1", "2"];
-      $scope.$apply()
-      expect(getCheckBoxValue(checkbox()[0])).toBe(true);
-      expect(getCheckBoxValue(checkbox()[1])).toBe(true);
-      
+    it('should render correct initial value', () => {
+      expect(getCheckBoxValue(checkbox1)).toBe(true);
+      expect(getCheckBoxValue(checkbox2)).toBe(false);
     });
   });
 
-  describe('interactions', function() {
-    it('should change the model when checkbox gets checked', function() {
-      expect(getCheckBoxValue(checkbox()[0])).toBeFalsy();
-      button()[0].click();
-      expect(getCheckBoxValue(checkbox()[0])).toBe(true);
-      expect($ngModel().$viewValue).toEqual(["1"]);
+  describe('when the model that is passed in changes', () => {
+    beforeEach(() => {
+      $scope.ngModel = [2];
+      $scope.$apply();
     });
+    it('should update the checkboxes to reflect the model', () => {
+      expect(getCheckBoxValue(checkbox1)).toBe(false);
+      expect(getCheckBoxValue(checkbox2)).toBe(true);
+    });
+  });
 
-    it('should pass "disabled" prop to checkboxes', function() {
-      expect(checkbox()[0].getAttribute('disabled')).toBe(null)
+  describe('when the checxboxes are clicked', () => {
+    beforeEach(() => {
+      button1.click();
+      button2.click();
+    });
+    it('should update the model', () => {
+      expect(getCheckBoxValue(checkbox1)).toBe(false);
+      expect(getCheckBoxValue(checkbox2)).toBe(true);
+      expect($element.controller('ngModel').$viewValue).toEqual([2]);
+    });
+  });
+
+  describe('when the control is disabled', () => {
+    beforeEach(() => {
       $scope.ngDisabled = true
       $scope.$apply();
-      expect(checkbox()[0].getAttribute('disabled')).toBe("disabled")
     });
+    it('should pass "disabled" prop to checkboxes', () => {
+      expect(checkbox1.getAttribute('disabled')).toBe("disabled");
+      expect(checkbox2.getAttribute('disabled')).toBe("disabled");
+    });
+  });
 
-    it('should be invalid when required, interacted with, and none of checkboxes is checked', function() {
-      var form = templateElement.find('.form-group');
-      expect(form.hasClass('has-error')).toBe(false);
-      button()[0].click();
-      $scope.$digest();
-      $timeout.flush();
-      expect(form.hasClass('has-error')).toBe(false);
-      button()[0].click();
-      $scope.$digest();
-      $timeout.flush();
-      expect(form.hasClass('has-error')).toBe(true);
+  describe('when a value is required, the control has been interacted with and none of the checkboxes are selected', () => {
+    fit('the form group should be invalid ', () => {
+      const formGroup = template.find('.form-group')[0];
+
+      expect(formGroup.classList).not.toContain('has-error');
+      button1.click();
+      expect(formGroup.classList).toContain('has-error');
+      button2.click();
+      expect(formGroup.classList).not.toContain('has-error');
     });
   });
 
   function getCheckBoxValue(checkbox) {
     return angular.element(checkbox).controller('ngModel').$viewValue;
   }
+
   function getCompiledTemplateElement($scope, template) {
     if (!template) {
       template = " \

--- a/src/forms/definition-list/definition-list.controller.js
+++ b/src/forms/definition-list/definition-list.controller.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+import { isArray } from '../../json-schema/validation/type-validators';
 
 class DefinitionListController {
   constructor(TwRequirementsService) {
@@ -27,6 +28,16 @@ class DefinitionListController {
       }
     }
     return value;
+  }
+
+  getCheckboxGroupLabel(options, valuesString) {
+    try {
+      const values = isArray(valuesString) ? valuesString : JSON.parse(valuesString);
+      const labels = values.map(value => this.getValueLabel(options, value));
+      return labels.join(', ');
+    } catch (error) {
+      return valuesString;
+    }
   }
 
   // eslint-disable-next-line

--- a/src/forms/definition-list/definition-list.html
+++ b/src/forms/definition-list/definition-list.html
@@ -31,6 +31,9 @@
             ng-src="{{ $ctrl.model[key] }}"
             ng-attr-alt="{{ field.title }}" />
         </div>
+        <span ng-switch-when="checkbox-group">
+          {{ $ctrl.getCheckboxGroupLabel(field.items.values, $ctrl.model[key]) }}
+        </span>
         <span ng-switch-default>
           {{ $ctrl.model[key] | twTextFormat: field.displayFormat }}
         </span>
@@ -61,6 +64,9 @@
                 ng-src="{{ $ctrl.model[fieldSection.key] }}"
                 ng-attr-alt="{{ field.title }}" />
             </div>
+            <span ng-switch-when="checkbox-group">
+              {{ $ctrl.getCheckboxGroupLabel(field.values, $ctrl.model[key]) }}
+            </span>
             <span ng-switch-default>
               {{ $ctrl.model[fieldSection.key] | twTextFormat: fieldSection.displayFormat }}
             </span>

--- a/src/forms/definition-list/definition-list.spec.js
+++ b/src/forms/definition-list/definition-list.spec.js
@@ -163,6 +163,31 @@ describe('Definition list', function() {
     });
   });
 
+  describe('when given a checkbox group field', function() {
+    beforeEach(function() {
+      $scope.model = {
+        key: [1,2]
+      };
+      $scope.fields = {
+        key: {
+          title: 'Checkbox group label',
+          type: 'array',
+          items: {
+            enum: [1,2],
+            values: [
+              { value: 1, label: 'One' },
+              { value: 2, label: 'Two' }
+            ]
+          }
+        }
+      };
+      setupVars();
+    });
+    it('should display the labes from the matching values', function() {
+      expect(definition.textContent.trim()).toBe('One, Two');
+    });
+  });
+
   describe('when given a password field', function() {
     beforeEach(function() {
       $scope.model = {

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -1,4 +1,6 @@
 import angular from 'angular';
+import { getValidModelParts } from '../../json-schema/validation/valid-model';
+import { isUndefined } from '../../json-schema/validation/type-validators';
 
 class FieldsetController {
   constructor(TwRequirementsService, $scope, $timeout) {
@@ -11,7 +13,10 @@ class FieldsetController {
     if (!this.model) {
       this.model = {};
     }
-    this.internalModel = this.parseModel();
+
+    this.internalModel = this.parseArrayStringsInModel(this.model);
+
+
     if (!this.requiredFields) {
       this.requiredFields = [];
     }
@@ -37,34 +42,69 @@ class FieldsetController {
   }
 
   $onChanges(changes) {
-    const fieldsChanged = changes.initialFields;
-    if (fieldsChanged) {
-      if (!angular.equals(fieldsChanged.currentValue, fieldsChanged.previousValue)) {
-        this.fields = this.RequirementsService.prepFields(
-          fieldsChanged.currentValue,
-          this.model,
-          this.validationMessages
-        );
-        this.internalModel = this.parseModel();
+    if (changes.initialFields) {
+      this.onPropsFieldChange(changes.initialFields);
+    }
 
-        if (!this.requiredFields || !this.requiredFields.length) {
-          this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
-        }
-      }
+    if (changes.model) {
+      this.onPropsModelChange(changes.model);
     }
   }
 
-  parseModel() {
+  onPropsFieldChange(fieldChanges) {
+    // Deep compare, do nothing if no changes
+    if (angular.equals(fieldChanges.currentValue, fieldChanges.previousValue)) {
+      return;
+    }
+
+    this.fields = this.RequirementsService.prepFields(
+      fieldChanges.currentValue,
+      this.model,
+      this.validationMessages
+    );
+
+    // Remove any model values that are now invalid
+    const oldModel = this.internalModel;
+    const newModel = getValidModelParts(oldModel, convertFieldsToObject(this.fields));
+
+    // Valid model returns null, not undefined so we must check oldModel
+    if (!isUndefined(oldModel) && !angular.equals(newModel, oldModel)) {
+      this.internalModel = newModel;
+      this.model = newModel;
+      if (this.onModelChange) {
+        this.onModelChange({ model: newModel });
+      }
+    }
+
+    if (!this.requiredFields || !this.requiredFields.length) {
+      this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
+    }
+  }
+
+  onPropsModelChange(modelChanges) {
+    // When the model changes convert array strings to real arrays (for checkbox-group)
+    this.internalModel = this.parseArrayStringsInModel(modelChanges.currentValue);
+  }
+
+  /**
+   * We have a limitation in V2 dynamic forms where the server needs a string
+   * { a: "[1]"} => { a: [1] }
+   */
+  parseArrayStringsInModel(model) {
     const parsedValues = {};
     Object.keys(this.fields).forEach((key) => {
       if (this.fields[key].control === 'checkbox-group' && this.model && typeof this.model[key] === 'string') {
         parsedValues[key] = JSON.parse(this.model[key]);
       }
     });
-    return { ...this.model, ...parsedValues };
+    return { ...model, ...parsedValues };
   }
 
-  stringifyObjectsInModel() {
+  /**
+   * We have a limitation in V2 dynamic forms where the server needs a string
+   * { a: [1]} => { a: "[1]"" }
+   */
+  stringifyArraysInModel(model) {
     const stringifiedValues = {};
     Object.keys(this.fields).forEach((key) => {
       if (this.fields[key].control === 'checkbox-group' && this.internalModel && this.internalModel[key]) {
@@ -72,7 +112,7 @@ class FieldsetController {
       }
     });
 
-    return { ...this.internalModel, ...stringifiedValues };
+    return { ...model, ...stringifiedValues };
   }
 
   fieldFocus(key, field) {
@@ -99,7 +139,7 @@ class FieldsetController {
 
     // Delay so model can update
     this.$timeout(() => {
-      this.model = this.stringifyObjectsInModel();
+      this.model = this.stringifyArraysInModel(this.internalModel);
       if (this.onFieldChange) {
         if (field && field.control === 'checkbox-group') {
           this.onFieldChange({ value: JSON.stringify(value), key, field });
@@ -131,6 +171,13 @@ class FieldsetController {
   setSubmitted() {
     this.submitted = true;
   }
+}
+
+function convertFieldsToObject(fields) {
+  return {
+    type: 'object',
+    properties: fields
+  };
 }
 
 FieldsetController.$inject = ['TwRequirementsService', '$scope', '$timeout'];

--- a/src/forms/fieldset/fieldset.demo.js
+++ b/src/forms/fieldset/fieldset.demo.js
@@ -174,16 +174,16 @@ function fieldsetDocsController() {
 
   this.fieldsetLayout = {
     properties: {
-      stringProperty: {
-        type: 'string',
-        title: 'String label',
-        placeholder: 'Please enter text',
-        width: 'md'
-      },
       booleanProperty: {
         type: 'boolean',
         title: 'Boolean label',
         placeholder: 'Check it',
+        width: 'lg'
+      },
+      stringProperty: {
+        type: 'string',
+        title: 'String label',
+        placeholder: 'Please enter text',
         width: 'md'
       },
       numberProperty: {
@@ -228,19 +228,6 @@ function fieldsetDocsController() {
           }
         ]
       },
-      checkboxGroup: {
-        title: 'Checkbox Group',
-        type: 'array',
-        control: 'checkbox-group',
-        width: 'md',
-        items: {
-          enum: [1, 2],
-          values: [
-            { value: 1, label: 'One' },
-            { value: 2, label: 'Two' }
-          ]
-        }
-      },
       password: {
         title: 'Password',
         type: 'string',
@@ -276,6 +263,19 @@ function fieldsetDocsController() {
             name: 'Two'
           }
         ]
+      },
+      checkboxGroup: {
+        title: 'Checkbox Group',
+        type: 'array',
+        control: 'checkbox-group',
+        width: 'md',
+        items: {
+          enum: [1, 2],
+          values: [
+            { value: 1, label: 'One' },
+            { value: 2, label: 'Two' }
+          ]
+        }
       },
       checkbox: {
         title: 'Checkbox',
@@ -313,6 +313,6 @@ function fieldsetDocsController() {
     radio: '2',
     password: 'qwerty',
     telephone: '+441234567890',
-    checkboxGroup: '["1"]'
+    checkboxGroup: '[1]'
   };
 }

--- a/src/forms/form-control/form-control.spec.js
+++ b/src/forms/form-control/form-control.spec.js
@@ -160,7 +160,7 @@ describe('FormControl', function() {
 
     testChangeHandler(function() {
       checkbox.querySelector('button').click();
-    }, ["1"]);
+    }, ['1']);
   });
 
   describe('type: radio', function() {

--- a/src/forms/select/select.demo.html
+++ b/src/forms/select/select.demo.html
@@ -15,7 +15,7 @@
       <label class="control-label" for="mySelect">
         Example select
       </label>
-      <tw-select tw-validation
+      <tw-select
         ng-if="!$ctrl.select.extraLink"
         name="mySelect"
         placeholder="{{$ctrl.select.empty}}"
@@ -39,7 +39,7 @@
         hide-circle="{{$ctrl.select.hideCircle}}"
         hide-label="{{$ctrl.select.hideLabel}}">
       </tw-select>
-      <tw-select tw-validation
+      <tw-select
         ng-if="$ctrl.select.extraLink"
         name="mySelect"
         placeholder="{{$ctrl.select.empty}}"
@@ -75,7 +75,7 @@
 
     <div class="form-inline m-b-3 visible-xs-inline-block visible-sm-inline-block
       visible-md-inline-block visible-lg-inline-block visible-xl-inline-block">
-      <tw-select tw-validation
+      <tw-select
         ng-if="!$ctrl.select.extraLink"
         name="mySelect"
         placeholder="{{$ctrl.select.empty}}"
@@ -99,7 +99,7 @@
         hide-circle="{{$ctrl.select.hideCircle}}"
         hide-label="{{$ctrl.select.hideLabel}}">
       </tw-select>
-      <tw-select tw-validation
+      <tw-select
         ng-if="$ctrl.select.extraLink"
         name="mySelect"
         placeholder="{{$ctrl.select.empty}}"
@@ -147,8 +147,7 @@
   hide-currency="{{$ctrl.select.hideCurrency}}"</span><span ng-if="$ctrl.select.hideCircle">
   hide-circle="{{$ctrl.select.hideCircle}}"</span><span ng-show="$ctrl.select.hideLabel">
   hide-label="{{$ctrl.select.hideLabel}}"</span>
-  options="{{$ctrl.select.options[$ctrl.select.type] | json}}"
-  tw-validation<span ng-if="!$ctrl.select.extraLink"> /&gt;</span><span ng-if="$ctrl.select.extraLink">&gt;
+  options="{{$ctrl.select.options[$ctrl.select.type] | json}}"<span ng-if="!$ctrl.select.extraLink"> /&gt;</span><span ng-if="$ctrl.select.extraLink">&gt;
     &lt;a href='' ng-click='...'&gt;
       Custom action
     &lt;/a&gt;

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -220,12 +220,25 @@ function RequirementsService($http) {
         field.type = 'string';
         field.control = 'textarea';
         break;
+      case 'array':
+        field.control = this.getControlForArray(field);
+        break;
       default:
     }
 
     if (!field.control && field.type !== 'object') {
       field.control = this.getControlType(field);
     }
+  };
+
+  this.getControlForArray = (field) => {
+    if (field.items.enum) {
+      return 'checkbox-group';
+    }
+    if (field.items.format === 'base64url') {
+      return 'multi-upload';
+    }
+    return null;
   };
 
   this.prepLegacyAlternatives = (alternative) => {

--- a/src/services/requirements/requirements.spec.js
+++ b/src/services/requirements/requirements.spec.js
@@ -240,6 +240,58 @@ describe('Requirements Service', function() {
       });
     });
 
+    describe('when preparing an array of enums', () => {
+      it('should identify as a checkbox group', () => {
+        var input = {
+          type: 'array',
+          items: {
+            enum: [1, 2],
+            values: [
+              { value: 1, label: 'One' },
+              { value: 2, label: 'Two' }
+            ]
+          }
+        };
+
+        var expectedOutput = {
+          type: 'array',
+          items: {
+            enum: [1, 2],
+            values: [
+              { value: 1, label: 'One' },
+              { value: 2, label: 'Two' }
+            ]
+          },
+          control: 'checkbox-group'
+        };
+
+        expect(service.prepField(input)).toEqual(expectedOutput);
+      })
+    });
+
+    describe('when preparing an array of base64Url', () => {
+      it('should identify as a checkbox group', () => {
+        var input = {
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'base64url'
+          }
+        };
+
+        var expectedOutput = {
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'base64url'
+          },
+          control: 'multi-upload'
+        };
+
+        expect(service.prepField(input)).toEqual(expectedOutput);
+      })
+    });
+
     describe('when preparing camera fields', function() {
       it('should rename \'overlay\' to \'outline\' on old guidelines', function() {
         var input = {

--- a/src/validation/control-validation/control-validation.controller.js
+++ b/src/validation/control-validation/control-validation.controller.js
@@ -30,6 +30,11 @@ class ValidationController {
 }
 
 function checkModelAndUpdate(ngModel, formGroup, element) {
+  if (!formGroup) {
+    // If there's no parent formGroup, nothin to update
+    return;
+  }
+
   // Option to switch off default validators
   if (formGroup.classList.contains('custom-validation')) {
     return;


### PR DESCRIPTION
## Context
Sometimes when we do a refresh of the form, we end up with different fields, in that case we should remove any properties from the model that no longer appear in the set of fields

## Changes
Alongside those changes we also improve the checkbox-group implementation to work with numeric enums as well as strings.  The requirements service now better identifies checkbox-groups based on their data type, and we have improved the definition list to show the labels for the enums rather than the raw values.

## Screenshots/GIFs
![image](https://user-images.githubusercontent.com/1318111/87456204-814e9f80-c5fe-11ea-9918-b7bdc48e3f54.png)
![image](https://user-images.githubusercontent.com/1318111/87456244-8dd2f800-c5fe-11ea-805f-b1e554f7d367.png)

## Checklist

- [ ] All changes are covered by tests