### PR TITLE
Change live-capture blob upload to File upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.1.0
+## Change upload from live capture to be File instead of blob
+PersistAsync uploads from web were failing because the blob was being send up without an extension. Now we turn the blob in to a file and send that up to be processed. 
+
 # v7.0.0
 ## Fieldsets now remove invalid properties from the model when receiving new fields
 BREAKING: If the set of fields is updated, any properties of the model that are not reflected in the new set of fields will be removed.  This could be a breaking change if a consumer relies on the fieldset leaving other properties of a model untouched.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -240,7 +240,7 @@ function createUploadCallback($ctrl) {
     $ctrl.showVideoPreview = false;
     $ctrl.closeVideoStream();
     $ctrl.$scope.$applyAsync(() => {
-      const file = new File([blob], 'image.jpeg', { type: 'image/jpeg' })
+      const file = new File([blob], 'image.jpeg', { type: 'image/jpeg' });
       $ctrl.onCapture({ file });
     });
   };

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -240,7 +240,8 @@ function createUploadCallback($ctrl) {
     $ctrl.showVideoPreview = false;
     $ctrl.closeVideoStream();
     $ctrl.$scope.$applyAsync(() => {
-      $ctrl.onCapture({ file: blob });
+      const file = new File([blob], 'image.jpeg', { type: 'image/jpeg' })
+      $ctrl.onCapture({ file });
     });
   };
 }

--- a/src/forms/upload/services/async-file-saver.service.js
+++ b/src/forms/upload/services/async-file-saver.service.js
@@ -13,8 +13,9 @@ class AsyncFileSaver {
 
     if (file[0].name === 'blob') {
       formData.append(key, file, fieldName + file[0].ext);
+    } else {
+      formData.append(key, file);
     }
-    formData.append(key, file);
 
     const $httpOptions = prepareHttpOptions(httpOptions);
 

--- a/src/forms/upload/services/async-file-saver.service.js
+++ b/src/forms/upload/services/async-file-saver.service.js
@@ -10,6 +10,10 @@ class AsyncFileSaver {
     }
     const formData = new FormData();
     const key = httpOptions.param || fieldName;
+
+    if (file[0].name === 'blob') {
+      formData.append(key, file, fieldName + file[0].ext);
+    }
     formData.append(key, file);
 
     const $httpOptions = prepareHttpOptions(httpOptions);


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
[Uploads from web are failing](https://production-logs.tw.ee/app/logtrail#/?q=%22Extension%20check%20failed%20for%20blob%22&h=All&t=last%20month&i=services-*&_g=()) for live capture photos that are uploaded using [PersistAsync](https://github.com/transferwise/mitigator-service/blob/b3e62363106cf9c250798f7904079f337b2e3eea/src/main/java/com/transferwise/mitigator/api/form/component/v2/verification/IdDocumentWithFrontFaceLivePhotoAlternativeV2.java#L48)

https://transferwise.slack.com/archives/C2SGDKP4Y/p1596072668439100

## Changes
<!-- what this PR does -->
I haven't finalized my changes but I'll either change the blob to a File right after it is captured or I'll rename the blob to have a JPEG extension before uploading (this seems riskier). 

## Considerations
<!-- additional info for reviewing, discussion topics -->
These changes are hard to test! They involve styleguide-components (which is consumed somewhere) and webapp. Any guidance on testing would be greatly appreciated.

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before
<img width="1143" alt="Screen Shot 2020-07-26 at 12 24 31 PM" src="https://user-images.githubusercontent.com/57100505/88484209-fd1fe480-cf3a-11ea-8c24-def94abc3653.png">
<img width="1593" alt="Screen Shot 2020-07-26 at 12 00 48 PM" src="https://user-images.githubusercontent.com/57100505/88484213-00b36b80-cf3b-11ea-9818-393f28bd1092.png">

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests