### PR TITLE
[IDWL-] Change upload from live capture to add the file extension if its not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v7.0.2
 
-## Change upload from live capture to be File instead of blob
+## Change upload from live capture to add the file extension if its not exist
 PersistAsync uploads from web were failing because the blob was being send up without an extension. Now we add the file extension to the file name if the extension is not present.
 
 # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v7.0.2
+
+## Change upload from live capture to be File instead of blob
+PersistAsync uploads from web were failing because the blob was being send up without an extension. Now we add the file extension to the file name if the extension is not present.
+
 # v7.0.1
 
 ## Pass latest model as parameter to Fieldset.onRefreshRequirements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/multi-upload/multi-upload.spec.js
+++ b/src/forms/upload/multi-upload/multi-upload.spec.js
@@ -584,12 +584,14 @@ describe("multi-upload", () => {
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileA,
-            $scope.httpOptions
+            $scope.httpOptions,
+            base64url
           );
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileB,
-            $scope.httpOptions
+            $scope.httpOptions,
+            base64url
           );
         });
 
@@ -614,12 +616,14 @@ describe("multi-upload", () => {
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileA,
-            $scope.httpOptions
+            $scope.httpOptions,
+            base64url
           );
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileB,
-            $scope.httpOptions
+            $scope.httpOptions,
+            base64url
           );
         });
 

--- a/src/forms/upload/multi-upload/multi-upload.spec.js
+++ b/src/forms/upload/multi-upload/multi-upload.spec.js
@@ -585,13 +585,13 @@ describe("multi-upload", () => {
             "myFile",
             fileA,
             $scope.httpOptions,
-            base64url
+            "file.png"
           );
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileB,
             $scope.httpOptions,
-            base64url
+            "file.png"
           );
         });
 
@@ -617,13 +617,13 @@ describe("multi-upload", () => {
             "myFile",
             fileA,
             $scope.httpOptions,
-            base64url
+            "file.png"
           );
           expect(AsyncFileSaver.save).toHaveBeenCalledWith(
             "myFile",
             fileB,
             $scope.httpOptions,
-            base64url
+            "file.png"
           );
         });
 

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -51,7 +51,7 @@ class Controller {
     if (this.httpOptions) {
       // Post file now
       this.asyncFileRead(file)
-        .then(dataUrl => this.asyncFileSave(file, this.parseFileName(dataUrl))
+        .then(dataUrl => this.asyncFileSave(file, Controller.parseFileName(dataUrl))
           .then(response => asyncSuccess(response, dataUrl, this)))
         .catch(error => asyncFailure(error, null, this));
     } else {
@@ -62,7 +62,7 @@ class Controller {
     }
   }
 
-  parseFileName(dataUrl) {
+  static parseFileName(dataUrl) {
     const match = dataUrl.match(/^data:[^/]+\/([^;]+);base64,/);
 
     return match ? `file.${match[1]}` : undefined;

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -51,7 +51,7 @@ class Controller {
     if (this.httpOptions) {
       // Post file now
       this.asyncFileRead(file)
-        .then(dataUrl => this.asyncFileSave(file, dataUrl)
+        .then(dataUrl => this.asyncFileSave(file, this.parseFileName(dataUrl))
           .then(response => asyncSuccess(response, dataUrl, this)))
         .catch(error => asyncFailure(error, null, this));
     } else {
@@ -60,6 +60,12 @@ class Controller {
         .then(dataUrl => asyncSuccess(null, dataUrl, this))
         .catch(error => asyncFailure(error, null, this));
     }
+  }
+
+  parseFileName(dataUrl) {
+    const match = dataUrl.match(/^data:[^/]+\/([^;]+);base64,/);
+
+    return match ? `file.${match[1]}` : undefined;
   }
 
   asyncFileSave(file, dataUrl) {

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -68,9 +68,9 @@ class Controller {
     return match ? `file.${match[1]}` : undefined;
   }
 
-  asyncFileSave(file, dataUrl) {
+  asyncFileSave(file, fileName) {
     const httpOptions = this.AsyncTasksConfig.extendHttpOptions(this.httpOptions);
-    return this.AsyncFileSaver.save(httpOptions.param || this.name, file, httpOptions, dataUrl);
+    return this.AsyncFileSaver.save(httpOptions.param || this.name, file, httpOptions, fileName);
   }
 
   asyncFileRead(file) {

--- a/src/forms/upload/processing-card/processing-card.controller.js
+++ b/src/forms/upload/processing-card/processing-card.controller.js
@@ -51,7 +51,7 @@ class Controller {
     if (this.httpOptions) {
       // Post file now
       this.asyncFileRead(file)
-        .then(dataUrl => this.asyncFileSave(file)
+        .then(dataUrl => this.asyncFileSave(file, dataUrl)
           .then(response => asyncSuccess(response, dataUrl, this)))
         .catch(error => asyncFailure(error, null, this));
     } else {
@@ -62,9 +62,9 @@ class Controller {
     }
   }
 
-  asyncFileSave(file) {
+  asyncFileSave(file, dataUrl) {
     const httpOptions = this.AsyncTasksConfig.extendHttpOptions(this.httpOptions);
-    return this.AsyncFileSaver.save(httpOptions.param || this.name, file, httpOptions);
+    return this.AsyncFileSaver.save(httpOptions.param || this.name, file, httpOptions, dataUrl);
   }
 
   asyncFileRead(file) {

--- a/src/forms/upload/services/async-file-saver.service.js
+++ b/src/forms/upload/services/async-file-saver.service.js
@@ -4,13 +4,12 @@ class AsyncFileSaver {
     this.$http = $http;
   }
 
-  save(fieldName, file, httpOptions, dataUrl) {
+  save(fieldName, file, httpOptions, fileName) {
     if (!httpOptions) {
       throw new Error('You must supply httpOptions');
     }
     const formData = new FormData();
     const key = httpOptions.param || fieldName;
-    const fileName = file.name || (dataUrl && parseFileName(dataUrl));
     formData.append(key, file, fileName);
 
     const $httpOptions = prepareHttpOptions(httpOptions);
@@ -20,12 +19,6 @@ class AsyncFileSaver {
     // For testing
     return this.$http.post($httpOptions.url, formData, $httpOptions);
   }
-}
-
-function parseFileName(dataUrl) {
-  const match = dataUrl.match(/^data:[^/]+\/([^;]+);base64,/);
-
-  return match ? `file.${match[1]}` : undefined;
 }
 
 function prepareHttpOptions($inputOptions) {

--- a/src/forms/upload/services/async-file-saver.service.js
+++ b/src/forms/upload/services/async-file-saver.service.js
@@ -4,13 +4,14 @@ class AsyncFileSaver {
     this.$http = $http;
   }
 
-  save(fieldName, file, httpOptions) {
+  save(fieldName, file, httpOptions, dataUrl) {
     if (!httpOptions) {
       throw new Error('You must supply httpOptions');
     }
     const formData = new FormData();
     const key = httpOptions.param || fieldName;
-    formData.append(key, file, file[0].name === 'blob' ? 'blob.jpeg' : undefined);
+    const fileName = file.name || (dataUrl && parseFileName(dataUrl));
+    formData.append(key, file, fileName);
 
     const $httpOptions = prepareHttpOptions(httpOptions);
 
@@ -21,6 +22,11 @@ class AsyncFileSaver {
   }
 }
 
+function parseFileName(dataUrl) {
+  const match = dataUrl.match(/^data:[^/]+\/([^;]+);base64,/);
+
+  return match ? `file.${match[1]}` : undefined;
+}
 
 function prepareHttpOptions($inputOptions) {
   const $httpOptions = angular.copy($inputOptions);

--- a/src/forms/upload/services/async-file-saver.service.js
+++ b/src/forms/upload/services/async-file-saver.service.js
@@ -10,7 +10,7 @@ class AsyncFileSaver {
     }
     const formData = new FormData();
     const key = httpOptions.param || fieldName;
-    formData.append(key, file);
+    formData.append(key, file, file[0].name === 'blob' ? 'blob.jpeg' : undefined);
 
     const $httpOptions = prepareHttpOptions(httpOptions);
 

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -197,7 +197,7 @@ describe('given an upload component', () => {
 
     it('should send the file to the asyncFileSaver', function() {
       expect(AsyncFileSaver.save).toHaveBeenCalledWith(
-        'myFile', mockFile, $scope.httpOptions
+        'myFile', mockFile, $scope.httpOptions, base64url
       );
     });
 

--- a/src/forms/upload/upload.spec.js
+++ b/src/forms/upload/upload.spec.js
@@ -197,7 +197,7 @@ describe('given an upload component', () => {
 
     it('should send the file to the asyncFileSaver', function() {
       expect(AsyncFileSaver.save).toHaveBeenCalledWith(
-        'myFile', mockFile, $scope.httpOptions, base64url
+        'myFile', mockFile, $scope.httpOptions, 'file.png'
       );
     });
 


### PR DESCRIPTION
## Context
Uploads from web are failing for live capture photos that are uploaded using `PersistAsync`

https://transferwise.slack.com/archives/C2SGDKP4Y/p1596072668439100

## Changes
As you can see at [processing-card.controller.js:54](https://github.com/transferwise/styleguide-components/pull/317/files#diff-edaa2d37a284510d3112b18de78ce543R54) we do compute the Base64 data URL of the `Blob` we get, but we are not using it, since the `mitigator-service` works with `MultipartFile`s instead of a `String` on that endpoint which would be risky to change.

Because we append a `Blob` instance to the form data without specifying the `fileName` argument, [it will default to the `blob` string](https://developer.mozilla.org/en-US/docs/Web/API/FormData/append) which is an invalid file name from the `mitigator-service` perspective.

To be backward compatible - if there is any other usages of the `AsyncFileSaver` service -, but still generic, we decided to try deducting the file extension from the already computed Base64 data URL, but if we fail to do so it just works as before.

## Considerations
Now the live image capture and upload with persist async to `mitigator-service` to `webapp` is failing. This change is a fix for that.
This is the cause of the failure: https://github.com/transferwise/webapp/blob/c981e42067d1321f4cac6ed463b36444b729b553/tw-plugins/tw-common/grails-app/services/com/transferwise/fx/user/document/FileUploadService.groovy#L96

### Before

![image](https://user-images.githubusercontent.com/59830457/89528497-71843e80-d7eb-11ea-9ecb-b35fdb13d35d.png)
![image](https://user-images.githubusercontent.com/59830457/89528532-7cd76a00-d7eb-11ea-9462-6bb250311f12.png)

## Checklist

- [ ] All changes are covered by tests