### PR TITLE
Allow custom validation messages with defaults as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.0.4
+## Fallback to default for validation message for individual fields
+Allows setting particular custom validation messages and the rest will fallback to default
+
 # v7.0.3
 ## Change upload from live capture to add the file extension if its not exist
 PersistAsync uploads from web were failing because the blob was being send up without an extension. Now we add the file extension to the file name if the extension is not present.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -21,16 +21,14 @@ class FieldsetController {
       this.requiredFields = [];
     }
 
-    if (!this.validationMessages) {
-      this.validationMessages = {
-        required: 'Required',
-        pattern: 'Incorrect format',
-        minimum: 'The value is too low',
-        maximum: 'The value is too high',
-        minLength: 'The value is too short',
-        maxLength: 'The value is too long'
-      };
-    }
+    this.validationMessages = Object.assign({
+      required: 'Required',
+      pattern: 'Incorrect format',
+      minimum: 'The value is too low',
+      maximum: 'The value is too high',
+      minLength: 'The value is too short',
+      maxLength: 'The value is too long'
+    }, this.validationMessages);
 
     this.$scope.$watch('twFieldset.$valid', (validity) => {
       this.isValid = validity;

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -21,14 +21,16 @@ class FieldsetController {
       this.requiredFields = [];
     }
 
-    this.validationMessages = Object.assign({
+    const defaultMessages = {
       required: 'Required',
       pattern: 'Incorrect format',
       minimum: 'The value is too low',
       maximum: 'The value is too high',
       minLength: 'The value is too short',
       maxLength: 'The value is too long'
-    }, this.validationMessages);
+    };
+
+    this.validationMessages = { ...defaultMessages, ...this.validationMessages };
 
     this.$scope.$watch('twFieldset.$valid', (validity) => {
       this.isValid = validity;

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -142,6 +142,24 @@ describe('Fieldset', function() {
     });
   });
 
+  describe('when only some custom validation messages are supplied', function() {
+    beforeEach(function() {
+      $scope.fields = getFields();
+      element = getCompiledDirectiveElement();
+    });
+    it('should fallback to default validation messages for remaining messages', function() {
+      var fields = element.querySelectorAll('tw-field');
+      var sortCodeField = angular.element(fields[0]);
+
+      expect(sortCodeField.controller('twField').validationStrings.required).toBe('sortCode required');
+      expect(sortCodeField.controller('twField').validationStrings.pattern).toBe('Incorrect format');
+      expect(sortCodeField.controller('twField').validationStrings.minimum).toBe('The value is too low');
+      expect(sortCodeField.controller('twField').validationStrings.maximum).toBe('The value is too high');
+      expect(sortCodeField.controller('twField').validationStrings.minLength).toBe('The value is too short');
+      expect(sortCodeField.controller('twField').validationStrings.maxLength).toBe('The value is too long');
+    });
+  });
+
   describe('when a field has refreshRequirementsOnChange: true', function() {
     beforeEach(function() {
       $scope.fields = getFields();
@@ -239,17 +257,6 @@ describe('Fieldset', function() {
       $scope.fields = getLegacyFields();
       element = getCompiledDirectiveElement();
       fields = element.querySelectorAll('tw-field');
-    });
-
-    it('validation messages have fallback when not supplied', function() {
-      var sortCodeField = angular.element(fields[0]);
-
-      expect(sortCodeField.controller('twField').validationStrings.required).toBe('sortCode required');
-      expect(sortCodeField.controller('twField').validationStrings.pattern).toBe('Incorrect format');
-      expect(sortCodeField.controller('twField').validationStrings.minimum).toBe('The value is too low');
-      expect(sortCodeField.controller('twField').validationStrings.maximum).toBe('The value is too high');
-      expect(sortCodeField.controller('twField').validationStrings.minLength).toBe('The value is too short');
-      expect(sortCodeField.controller('twField').validationStrings.maxLength).toBe('The value is too long');
     });
 
     it('should show the correct number of fields', function() {

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -241,6 +241,17 @@ describe('Fieldset', function() {
       fields = element.querySelectorAll('tw-field');
     });
 
+    it('validation messages have fallback when not supplied', function() {
+      var sortCodeField = angular.element(fields[0]);
+
+      expect(sortCodeField.controller('twField').validationStrings.required).toBe('sortCode required');
+      expect(sortCodeField.controller('twField').validationStrings.pattern).toBe('Incorrect format');
+      expect(sortCodeField.controller('twField').validationStrings.minimum).toBe('The value is too low');
+      expect(sortCodeField.controller('twField').validationStrings.maximum).toBe('The value is too high');
+      expect(sortCodeField.controller('twField').validationStrings.minLength).toBe('The value is too short');
+      expect(sortCodeField.controller('twField').validationStrings.maxLength).toBe('The value is too long');
+    });
+
     it('should show the correct number of fields', function() {
       expect(fields.length).toBe(2);
     });


### PR DESCRIPTION
## Context
Custom validation messages can be set for just particular fields. Previously you need to set it for all of the validations or none

For example if we set: 
```
"validationMessages": {
                              "pattern": "wrong format"
                          },
```

Missing validation message for `required` will fallback to default.

## Changes
Default values combine with custom validation messages

## Considerations
Added this after adding validation messages support to df v2 https://github.com/transferwise/dynamic-interfaces/commit/9963af0a5ce81801d82ccd484ff15ff65a0202cc

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests