### PR TITLE
ASIA-3207: Try changing the requested width/height of webcam requests again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v7.0.5
+## Change requested size of images uploaded through the camera component again
+This is a hopeful fix for the occasional image corruption issue of camera images getting chopped up into 4 or 8 layers
+
 # v7.0.4
 ## Fallback to default for validation message for individual fields
 Allows setting particular custom validation messages and the rest will fallback to default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.2",
+  "version": "7.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/forms/upload/camera-capture/camera-capture.controller.js
+++ b/src/forms/upload/camera-capture/camera-capture.controller.js
@@ -161,8 +161,8 @@ class CameraCaptureController {
 
       this.cameraConstraints = {
         video: {
-          width: { ideal: 1600 },
-          height: { ideal: 1600 },
+          width: { ideal: 1536 },
+          height: { ideal: 2048 },
           facingMode: {
             ideal: this.guidelines.direction.toLowerCase()
           }


### PR DESCRIPTION
## Changes
We want to change the camera context requested by our camera capture component from a square to a 3:4 portrait image.

## Context
This is a continuation of https://github.com/transferwise/styleguide-components/pull/298. Japan verification (and now Malaysia verification, and soon enough IDWL verification) has been plagued by this occasional issue where sometimes the image captured by the live camera component is corrupted, and looks like the attached screenshot (I've blurred out the PII, but if I didn't, you'd see that the card details get chopped too, and thus miss out some information)

![1596466881834](https://user-images.githubusercontent.com/2840821/91811205-b7ed8180-ec61-11ea-9f9b-a5c049a8190d.png)

We don't know the exact root cause for why this happens (and we haven't been able to reproduce it locally). What we do know is:

- when it happens, the pictures are always the exact square dimensions requested (browsers/devices are free to not follow the ideal dimensions exactly and give what they think is a best fit. But in all error cases, we've seen that the corrupted images are always 1600x1600 (or 2300x2300 when we requested for that previously)
- it's always chopped into 4 or 8 horizontal layers
- The fact that it happens at this confirmation step, suggests that it has something to do with copying the image data over from the `<video />` to the `<canvas />` (and not from a `<canvas />` to the final jpeg, which happens in a later step)
- we don't recall this happening prior to https://github.com/transferwise/styleguide-components/pull/293. Promisingly, back then, we were requesting for a rectangular, not square image. So that's some basis for this current PR
- Japan verification has 2 sections needing the camera: 3 ID sides, followed by 1 selfie. We see that customers sometimes have 3 IDs corrupted, or 1 selfie corrupted, or all 4 corrupted - generally the 3-ID section is all-or-nothing.

Our best guess at the moment is that this is a lower-level browser/video/canvas/mediadevices bug, and we're trying to tweak input parameters until we can successfully avoid it.

## Checklist

- [ ] All changes are covered by tests