### PR TITLE
fix: support V2 hidden fields in requirements service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v7.0.6
+## Support V2 hidden fields in requirements service, add oneOfs to select fields
+The requirements service, which maps V2 dynamic form specifications to V3, was missing support for hidden field types. This became apparent when we started to remove 'undocumented' fields, as we were removing values from hidden fields.
+
+We were also removing data from select fields, because our 'model cleaning' code expects JSON schema style 'oneOf' selects, not 'values' arrays.
+
+We now correctly map hidden fields to hidden string schemas. We now add 'oneOf' arrays next to our 'values' array to enable validation to work correctly
+
 # v7.0.5
 ## Change requested size of images uploaded through the camera component again
 This is a hopeful fix for the occasional image corruption issue of camera images getting chopped up into 4 or 8 layers
@@ -11,7 +19,7 @@ Allows setting particular custom validation messages and the rest will fallback 
 PersistAsync uploads from web were failing because the blob was being send up without an extension. Now we add the file extension to the file name if the extension is not present.
 
 # v7.0.2
-## Fix release build by correcting changelog format 
+## Fix release build by correcting changelog format
 
 # v7.0.1
 ## Pass latest model as parameter to Fieldset.onRefreshRequirements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "7.0.4",
+  "version": "7.0.6",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -223,6 +223,10 @@ function RequirementsService($http) {
       case 'array':
         field.control = this.getControlForArray(field);
         break;
+      case 'hidden':
+        field.type = 'string';
+        field.hidden = true;
+        break;
       default:
     }
 
@@ -305,6 +309,10 @@ function RequirementsService($http) {
 
     if (field.values && field.values.map) {
       field.values = this.prepLegacyValues(field.values);
+
+      const convertValueToConst = value => ({ const: value.value, title: value.label });
+
+      field.oneOf = field.values.map(convertValueToConst);
     }
 
     if (field.value && !field.default) {
@@ -456,11 +464,7 @@ function RequirementsService($http) {
   // not the outline.
   // Remove when legacy producers have been upgraded (Japan eKYC live uploads).
   this.prepCameraGuidelines = (field) => {
-    if (
-      field.camera
-      && field.camera.overlay
-      && !field.camera.outline
-    ) {
+    if (field.camera && field.camera.overlay && !field.camera.outline) {
       field.camera.outline = field.camera.overlay;
       delete field.camera.overlay;
     }

--- a/src/services/requirements/requirements.spec.js
+++ b/src/services/requirements/requirements.spec.js
@@ -31,38 +31,43 @@ describe('Requirements Service', function() {
     it('should convert old types to JSON schema', function() {
       var legacy = {
         typeText: { type: "text" },
+        typeHidden: { type: "hidden" },
         typeDate: { type: "date" },
         typePassword: { type: "password" },
         typeCheckbox: { type: "checkbox" },
         typeUpload: { type: "upload" },
         typeUPLOAD: { type: "UPLOAD" },
-        typeSelect: { type: "select", values: [] },
+        typeSelect: { type: "select", valuesAllowed: [{key: 1, label: "One"}] },
         typeRadio: { type: "radio", values: [], control: "select" },
         typeSelectWithRadioControl: { type: "select", values: [], control: "radio" },
       };
 
       var current = {
         typeText: { type: "string", control: "text" },
+        typeHidden: { type: "string", hidden: true, control: "hidden" },
         typeDate: { type: "string", format: "date", control: "date" },
         typePassword: { type: "string", control: "password" },
         typeCheckbox: { type: "boolean", control: "checkbox" },
         typeUpload: { type: "string", format: "base64url", control: "file" },
         typeUPLOAD: { type: "string", format: "base64url", control: "file" },
-        typeSelect: { values: [], control: "select" },
-        typeRadio: { values: [], control: "radio" },
-        typeSelectWithRadioControl: { values: [], control: "radio" },
+        typeSelect: { values: [{value: 1, label: "One"}], oneOf: [{const:1, title: "One"}], control: "select" },
+        typeRadio: { values: [], oneOf: [], control: "radio" },
+        typeSelectWithRadioControl: { values: [], oneOf: [], control: "radio" },
       };
 
       expect(service.prepFields(legacy)).toEqual(current);
     });
 
-    it('should convert old valuesAllowed to new values', function() {
+    it('should convert old valuesAllowed to new values and oneOf', function() {
       var legacy = {
         typeSelect: { type: "select", valuesAllowed: [{ key: 1, name: "One"}] }
       };
 
       var current = {
-        typeSelect: { values: [{ value: 1, label: "One"}], control: "select" }
+        typeSelect: {
+          values: [{ value: 1, label: "One"}],
+          oneOf: [{ const: 1, title: "One"}],
+          control: "select" }
       };
 
       expect(service.prepFields(legacy)).toEqual(current);


### PR DESCRIPTION
## Context
The requirements service, which maps V2 dynamic form specifications to V3, was missing support for hidden field types.  This became apparent when we started to remove 'undocumented' fields, as we were removing values from hidden fields.

We were also removing data from select fields, because our 'model cleaning' code expects JSON schema style 'oneOf' selects, not 'values' arrays. 

## Changes
We now correctly map hidden fields to hidden string schemas.  We now add 'oneOf' arrays next to our 'values' array to enable validation to work correctly

## Considerations
n/a

## Original Pull Request (for version bumps)
n/a

## Screenshots/GIFs
n/a

### Before
n/a

### After
n/a

## Checklist

- [x] All changes are covered by tests