### PR TITLE
fix: do not remove array values from models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.0.1
+## Fix behaviour of model validation on array schemas
+
 # v8.0.0
 ## Icons v2 and Neptune CSS
 
@@ -13,10 +16,10 @@ Now this package relies on `transferwise/icon` as source of icons and `@transfer
 ## Exclude angular icons from package bundle
 
 # v7.0.7-beta.1
-## Exclude angular icons from package bundle 
+## Exclude angular icons from package bundle
 
 # v7.0.7
-## Fix checkbox values fields mapping 
+## Fix checkbox values fields mapping
 
 # v7.0.6
 ## Support V2 hidden fields in requirements service, add oneOfs to select fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/json-schema/validation/valid-model/index.js
+++ b/src/json-schema/validation/valid-model/index.js
@@ -65,7 +65,9 @@ function cleanModelWithObjectSchema(model, schema) {
 
 function cleanModelWithArraySchema(model, schema) {
   if (isArray(model)) {
-    return model.map(childModel => getValidModelParts(childModel, schema));
+    return model
+      .map(itemModel => getValidModelParts(itemModel, schema.items))
+      .filter(itemModel => !isNull(itemModel));
   }
   return null;
 }

--- a/src/json-schema/validation/valid-model/index.js
+++ b/src/json-schema/validation/valid-model/index.js
@@ -69,7 +69,7 @@ function cleanModelWithArraySchema(model, schema) {
       .map(itemModel => getValidModelParts(itemModel, schema.items))
       .filter(itemModel => !isNull(itemModel));
   }
-  return null;
+  return [];
 }
 
 function cleanModelWithStringSchema(model) {

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -413,14 +413,25 @@ describe('Given a library for returning the valid parts of a model based on a sc
       };
     });
 
-    it('should return an array containing the valid items', () => {
-      expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
-      expect(getValidModelParts(['a', 1], schema)).toEqual(['a']);
-      expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
-      expect(getValidModelParts({}, schema)).toEqual([]);
-      expect(getValidModelParts('a', schema)).toEqual([]);
-      expect(getValidModelParts(1, schema)).toEqual([]);
-      expect(getValidModelParts(true, schema)).toEqual([]);
+    describe('and the model contains valid values', () => {
+      it('should return the original array', () => {
+        expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);  
+      });
+
+    describe('and the model contains invalid values', () => {
+      it('should remove the invalid values', () => {
+          expect(getValidModelParts(['a', 1], schema)).toEqual(['a']);
+          expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
+      });
+    });
+
+    describe('and the model is not an array', () => {
+      it('should return an empty array', () => {
+        expect(getValidModelParts({}, schema)).toEqual([]);
+        expect(getValidModelParts('a', schema)).toEqual([]);
+        expect(getValidModelParts(1, schema)).toEqual([]);
+        expect(getValidModelParts(true, schema)).toEqual([]);
+      });
     });
   });
 
@@ -438,10 +449,6 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts(['a', 'b', 'c'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
-      expect(getValidModelParts({}, schema)).toEqual([]);
-      expect(getValidModelParts('a', schema)).toEqual([]);
-      expect(getValidModelParts(1, schema)).toEqual([]);
-      expect(getValidModelParts(true, schema)).toEqual([]);
     });
   });
 });

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -402,4 +402,38 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(result).toEqual(model);
     });
   });
+
+  describe('when cleaning a simple array schema', () => {
+    beforeEach(() => {
+      schema = {
+        type: 'array',
+        items: {
+          type: 'string'
+        },
+      };
+    });
+
+    it('should return an array containing the valid items', () => {
+      expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
+      expect(getValidModelParts(['a', 1], schema)).toEqual(['a']);
+      expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
+    });
+  });
+
+  describe('when cleaning an array of enums schema', () => {
+    beforeEach(() => {
+      schema = {
+        type: 'array',
+        items: {
+          enum: ['a', 'b']
+        },
+      };
+    });
+
+    it('should return an array containing the valid items', () => {
+      expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
+      expect(getValidModelParts(['a', 'b', 'c'], schema)).toEqual(['a', 'b']);
+      expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
+    });
+  });
 });

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -415,8 +415,9 @@ describe('Given a library for returning the valid parts of a model based on a sc
 
     describe('and the model contains valid values', () => {
       it('should return the original array', () => {
-        expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);  
+        expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
       });
+    });
 
     describe('and the model contains invalid values', () => {
       it('should remove the invalid values', () => {
@@ -447,6 +448,9 @@ describe('Given a library for returning the valid parts of a model based on a sc
 
     it('should return an array containing the valid items', () => {
       expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
+    });
+
+    it('should remove items not in the enum set', () => {
       expect(getValidModelParts(['a', 'b', 'c'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
     });

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -420,6 +420,7 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(getValidModelParts({}, schema)).toEqual([]);
       expect(getValidModelParts('a', schema)).toEqual([]);
       expect(getValidModelParts(1, schema)).toEqual([]);
+      expect(getValidModelParts(true, schema)).toEqual([]);
     });
   });
 
@@ -440,6 +441,7 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(getValidModelParts({}, schema)).toEqual([]);
       expect(getValidModelParts('a', schema)).toEqual([]);
       expect(getValidModelParts(1, schema)).toEqual([]);
+      expect(getValidModelParts(true, schema)).toEqual([]);
     });
   });
 });

--- a/src/json-schema/validation/valid-model/spec.js
+++ b/src/json-schema/validation/valid-model/spec.js
@@ -417,6 +417,9 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts(['a', 1], schema)).toEqual(['a']);
       expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
+      expect(getValidModelParts({}, schema)).toEqual([]);
+      expect(getValidModelParts('a', schema)).toEqual([]);
+      expect(getValidModelParts(1, schema)).toEqual([]);
     });
   });
 
@@ -434,6 +437,9 @@ describe('Given a library for returning the valid parts of a model based on a sc
       expect(getValidModelParts(['a', 'b'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts(['a', 'b', 'c'], schema)).toEqual(['a', 'b']);
       expect(getValidModelParts([1, true, {}], schema)).toEqual([]);
+      expect(getValidModelParts({}, schema)).toEqual([]);
+      expect(getValidModelParts('a', schema)).toEqual([]);
+      expect(getValidModelParts(1, schema)).toEqual([]);
     });
   });
 });

--- a/src/services/requirements/requirements.spec.js
+++ b/src/services/requirements/requirements.spec.js
@@ -75,7 +75,12 @@ describe('Requirements Service', function() {
 
     it('should convert old valuesAllowed to item values for checkbox', function() {
       var legacy = {
-        checkboxGroup: { type: "select", control: "select", selectType: "CHECKBOX",  valuesAllowed: [{ key: 1, name: "One"}] }
+        checkboxGroup: {
+          type: "select",
+          control: "select",
+          selectType: "CHECKBOX",
+          valuesAllowed: [{ key: 1, name: "One"}]
+        }
       };
 
       var current = {


### PR DESCRIPTION
## Context
We were encountering a bug in V2 dynamic forms, where an array of enums (visually speaking a list of checkboxes) was being removed from the data model during a refresh.  This was occurring because the code that removed invalid values from models was not correctly implemented for array schemas.

## Changes
Ensure that invalid array entries are removed from arrays, and valid entries retained.

## Considerations
<!-- additional info for reviewing, discussion topics -->
Fix will also require a bump in verification-components

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->
n/a

## Screenshots/GIFs
<!-- required for all visual changes -->
n/a

### Before
<!-- screenshot before change -->
n/a

### After
<!-- screenshot after change -->
n/a

## Checklist

- [x] All changes are covered by tests