### PR TITLE
fix: force digest when file input value changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.0.2
+## Force a digest when a file input value changes
+
 # v8.0.1
 ## Fix behaviour of model validation on array schemas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/file-input.directive.js
+++ b/src/forms/upload/file-input.directive.js
@@ -20,8 +20,8 @@ class FileInputController {
         this.onUserInput();
         // TODO remove this log once digest bug fully resolved.
         console.log('DEBUG: file input value changed'); // eslint-disable-line
-        // Here we force a digest, because we were seeing failures to begin
-        // processing the file when used in other projects.
+        // Here, we force a digest because we were seeing failures to begin
+        // processing when used in other projects.
         if ($scope.$root.$$phase !== '$apply' && $scope.$root.$$phase !== '$digest') {
           $scope.$apply();
         }

--- a/src/forms/upload/file-input.directive.js
+++ b/src/forms/upload/file-input.directive.js
@@ -12,17 +12,24 @@ function FileInputDirective() {
 }
 
 class FileInputController {
-  constructor($element) {
+  constructor($element, $scope) {
     const element = $element[0];
     element.addEventListener('change', () => {
       if (this.onUserInput
         && typeof this.onUserInput === 'function') {
         this.onUserInput();
+        // TODO remove this log once digest bug fully resolved.
+        console.log('DEBUG: file input value changed'); // eslint-disable-line
+        // Here we force a digest, because we were seeing failures to begin
+        // processing the file when used in other projects.
+        if ($scope.$root.$$phase !== '$apply' && $scope.$root.$$phase !== '$digest') {
+          $scope.$apply();
+        }
       }
     });
   }
 }
 
-FileInputController.$inject = ['$element'];
+FileInputController.$inject = ['$element', '$scope'];
 
 export default FileInputDirective;


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
We encountered a situation where the upload component might get stuck, and not process a file upload.  This seemed to occur only when uploading a second file within the same upload component.  Once a subsequent interaction occurs the file begins processing.  This suggests the digest cycle is failing to run in this scenario.

## Changes
If one is not already running, we manually force a digest cycle after receiving the change event from the underlying file input control.

## Considerations
This PR contains a console.log which is present to help us understand the problem further if the fix does not work.

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests