### PR TITLE
feat: microapps media API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.1.0
+## Add Google microapp's Media Api support for file upload
+
 # v8.0.3
 ## Fix cancel and confirm buttons for camera upload component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2094,7 +2094,7 @@
       "dev": true,
       "requires": {
         "@transferwise/neptune-tokens": "^1.0.0",
-        "bootstrap": "github:transferwise/bootstrap#1328e4e8cad4e200b887b67854d8fd9e8083f6a3",
+        "bootstrap": "github:transferwise/bootstrap#semver:^5.20.0",
         "svgo": "1.3.2"
       },
       "dependencies": {
@@ -6265,7 +6265,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6286,12 +6287,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6306,17 +6309,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6433,7 +6439,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6445,6 +6452,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6459,6 +6467,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6466,12 +6475,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6490,6 +6501,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6570,7 +6582,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6582,6 +6595,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6667,7 +6681,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6703,6 +6718,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6722,6 +6738,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6765,12 +6782,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6780,7 +6799,7 @@
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
       "dev": true,
       "requires": {
-        "icu4c-data": "^0.62.2"
+        "icu4c-data": "^0.64.2"
       }
     },
     "function-bind": {
@@ -10533,7 +10552,8 @@
                 "ansi-regex": {
                   "version": "2.1.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -10554,12 +10574,14 @@
                 "balanced-match": {
                   "version": "1.0.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -10574,17 +10596,20 @@
                 "code-point-at": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -10701,7 +10726,8 @@
                 "inherits": {
                   "version": "2.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
@@ -10713,6 +10739,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -10727,6 +10754,7 @@
                   "version": "3.0.4",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -10734,12 +10762,14 @@
                 "minimist": {
                   "version": "0.0.8",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minipass": {
                   "version": "2.3.5",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.2",
                     "yallist": "^3.0.0"
@@ -10758,6 +10788,7 @@
                   "version": "0.5.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -10838,7 +10869,8 @@
                 "number-is-nan": {
                   "version": "1.0.1",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
@@ -10850,6 +10882,7 @@
                   "version": "1.4.0",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -10935,7 +10968,8 @@
                 "safe-buffer": {
                   "version": "5.1.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -10971,6 +11005,7 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -10990,6 +11025,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -11033,12 +11069,14 @@
                 "wrappy": {
                   "version": "1.0.2",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.3",
                   "bundled": true,
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.0.3",
+  "version": "8.1.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/capture-card/capture-card.html
+++ b/src/forms/upload/capture-card/capture-card.html
@@ -35,7 +35,7 @@
 
   <!-- file upload -->
   <tw-upload-button
-    ng-if="!$ctrl.isLiveCameraUpload"
+    ng-if="!($ctrl.isLiveCameraUpload || $ctrl.isMediaUpload)"
     name="$ctrl.name"
     label="$ctrl.buttonText"
     accept="$ctrl.accept"
@@ -44,9 +44,9 @@
     on-capture="$ctrl.onButtonCapture(files)">
   </tw-upload-button>
 
-  <!-- camera only upload -->
+  <!-- camera only or media only upload -->
   <tw-camera-button
-    ng-if="$ctrl.isLiveCameraUpload"
+    ng-if="$ctrl.isLiveCameraUpload || $ctrl.isMediaUpload"
     label="$ctrl.buttonText"
     disabled="$ctrl.ngDisabled"
     on-click="$ctrl.onCameraButtonClick()">

--- a/src/forms/upload/capture-card/card-capture.spec.js
+++ b/src/forms/upload/capture-card/card-capture.spec.js
@@ -1,0 +1,187 @@
+import screenfull from 'screenfull';
+
+describe('given a Card Capture component', () => {
+  let $scope, $compile, $component, $window, element, $q, component, controller, MediaApiService;
+
+  const template = `
+    <tw-upload-capture
+      label="label"
+      button-text="buttonText"
+      placeholder="placeholder"
+      is-live-camera-upload="isLiveCameraUpload"
+      on-file-capture="onFileCapture(file)"
+    ></tw-upload-capture>`;
+
+  beforeEach(function () {
+    angular.mock.module('tw.styleguide.forms.upload');
+
+    inject(($injector) => {
+      $compile = $injector.get('$compile');
+      $window = $injector.get('$window');
+      $scope = $injector.get('$rootScope').$new();
+      $q = $injector.get('$q');
+      MediaApiService = $injector.get('MediaApiService');
+    })
+  })
+
+  describe('when initialised', () => {
+    beforeEach(() => {
+      $scope.onFileCapture = jest.fn();
+      $scope.label = 'Front of your ID document';
+      $scope.placeholder = 'files hould be less than 10MB';
+      $scope.buttonText = 'Choose a file';
+
+      jest.spyOn(MediaApiService, 'hasMediaUploadSupport').mockReturnValue(false);
+
+      compileComponent();
+    })
+
+    it('should render an icon', () => {
+      expect(component.querySelector('tw-icon')).toBeTruthy();
+    });
+
+    it('should render the label', () => {
+      const label = compileTemplate(template).querySelector('h4.m-b-1');
+      expect(label.textContent.trim()).toContain($scope.label);
+    });
+
+    it('should render the placeholder', () => {
+      const placeholder = compileTemplate(template).querySelector('p.m-b-2');
+      expect(placeholder.textContent.trim()).toContain($scope.placeholder);
+    });
+
+    it('should render an upload button', () => {
+      expect(component.querySelector('tw-upload-button')).toBeTruthy();
+    });
+
+    it('should check for media upload support', () => {
+      expect(MediaApiService.hasMediaUploadSupport).toHaveBeenCalled();
+    })
+  })
+
+  describe('when isLiveCameraUpload is true and media upload is not supported', () => {
+    beforeEach(() => {
+      $scope.isLiveCameraUpload = true;
+
+      $window.navigator.mediaDevices = {
+        getUserMedia: jest.fn(() => $q.resolve({
+          getTracks: jest.fn(() => [])
+        })),
+      }
+
+      screenfull.request.mockImplementation(() => $q.resolve());
+      HTMLMediaElement.prototype.play = jest.fn(() => $q.resolve());
+
+      compileComponent();
+    })
+
+    it('should render a camera button', () => {
+      expect(findCameraButton()).toBeTruthy();
+    })
+
+    it('should render camera capture when camera button is clicked', () => {
+      findCameraButton().click();
+      expect(component.querySelector('tw-camera-capture')).toBeTruthy();
+    })
+  })
+
+  describe('when media upload is supported', () => {
+    let deferred;
+
+    beforeEach(() => {
+      deferred = $q.defer();
+
+      jest.spyOn(MediaApiService, 'hasMediaUploadSupport').mockReturnValue(true);
+      jest.spyOn(MediaApiService, 'captureFromMedia').mockReturnValue(deferred.promise);
+    })
+
+    it('should render a camera button', () => {
+      expect(findCameraButton()).toBeTruthy();
+    })
+
+    describe('when isLiveCameraUpload is true', () => {
+      describe('when camera button is clicked', () => {
+        beforeEach(() => {
+          $scope.isLiveCameraUpload = true;
+
+          compileComponent();
+        })
+
+        it('should call captureFromMedia from MediaApiService with true when camera button is clicked', () => {
+          findCameraButton().click();
+          expect(MediaApiService.captureFromMedia).toHaveBeenCalledWith(true);
+        })
+      })
+    })
+
+    describe('when isLiveCameraUpload is false', () => {
+      describe('when camera button is clicked', () => {
+        beforeEach(() => {
+          $scope.isLiveCameraUpload = false;
+
+          compileComponent();
+        })
+
+        it('should call captureFromMedia from MediaApiService with true when camera button is clicked', () => {
+          findCameraButton().click();
+          expect(MediaApiService.captureFromMedia).toHaveBeenCalledWith(false);
+        })
+      })
+    })
+
+    describe('when camera button is clicked', () => {
+      beforeEach(() => {
+        $scope.onFileCapture = jest.fn();
+
+        compileComponent();
+        findCameraButton().click();
+      })
+
+      describe('when captureFromMedia is successful', () => {
+        const file = { size: 124, type: 'image/jpeg'};
+
+        beforeEach(() => {
+          deferred.resolve(file);
+          $scope.$apply();
+        })
+
+        it('should call onFileCapture with ressolved file', () => {
+          expect($scope.onFileCapture).toHaveBeenCalledWith(file);
+        })
+      })
+
+      describe('when captureFromMedia fails', () => {
+        beforeEach(() => {
+          deferred.reject({error: 'CANCELLED'});
+          $scope.$apply();
+        })
+
+        it('should not call onFileCapture', () => {
+          expect($scope.onFileCapture).not.toHaveBeenCalled();
+        })
+      })
+    })
+  })
+
+  function compileComponent() {
+    element = angular.element(template);
+    $component = $compile(element)($scope);
+    $scope.$digest();
+    controller = $component.controller('twUploadCapture');
+    component = $component[0];
+  }
+
+  function compileTemplate(template) {
+    return compileElement(angular.element(template))[0];
+  }
+
+  function compileElement(element) {
+    var compiledElement = $compile(element)($scope);
+    $scope.$digest();
+    return compiledElement;
+  }
+
+  function findCameraButton() {
+    return component.querySelector('tw-camera-button label');
+  }
+})

--- a/src/forms/upload/capture-card/card-capture.spec.js
+++ b/src/forms/upload/capture-card/card-capture.spec.js
@@ -122,7 +122,7 @@ describe('given a Card Capture component', () => {
           compileComponent();
         })
 
-        it('should call captureFromMedia from MediaApiService with true when camera button is clicked', () => {
+        it('should call captureFromMedia from MediaApiService with false when camera button is clicked', () => {
           findCameraButton().click();
           expect(MediaApiService.captureFromMedia).toHaveBeenCalledWith(false);
         })

--- a/src/forms/upload/processing-card/index.js
+++ b/src/forms/upload/processing-card/index.js
@@ -4,6 +4,7 @@ import ProcessingMini from './processing-mini.component';
 import AsyncFileReader from '../services/async-file-reader.service.js';
 import AsyncFileSaver from '../services/async-file-saver.service.js';
 import FileValidationService from '../services/file-validation.service.js';
+import MediaApiService from '../services/media-api.service.js';
 import AsyncTasksConfig from '../../../services/asyncTasksConfig';
 import Process from '../../../loading/process';
 
@@ -13,6 +14,7 @@ export default angular
     AsyncFileReader,
     AsyncFileSaver,
     FileValidationService,
+    MediaApiService,
     Process
   ])
   .component('twUploadProcessing', ProcessingCard)

--- a/src/forms/upload/services/media-api.service.js
+++ b/src/forms/upload/services/media-api.service.js
@@ -1,0 +1,87 @@
+import angular from 'angular';
+
+/**
+ * MediaApiService exposes the Media API of Google Spot's microapps.
+ * We are only supporting media uploads with this API for web apps rendered
+ * in an iframe within predefined TransferWise's Google Spot App hosts.
+ * https://developers.google.com/pay/spot/eap/reference/media-api
+ */
+class MediaApiService {
+  constructor($window, $document, $q) {
+    this.$window = $window;
+    this.$document = $document;
+    this.$q = $q;
+    this.microappsHostnames = ['www.microapps.google.com', 'microapps-prod-tt.sandbox.google.com'];
+  }
+
+  captureFromMedia(isLiveCameraUpload) {
+    const request = {
+      allowedMimeTypes: ['image/jpeg', ...(isLiveCameraUpload ? [] : ['application/pdf'])],
+      allowedSources: ['camera', ...(isLiveCameraUpload ? [] : ['files'])]
+    };
+
+    const deferred = this.$q.defer();
+
+    this.$window.microapps.requestMedia(request)
+      .then((response) => {
+        const file = this.getBlobFromMedia(response);
+        return deferred.resolve(file);
+      }).catch(error => deferred.reject(error));
+
+    return deferred.promise;
+  }
+
+  /**
+   * Checks if page is in an iframe within TransferWise's predefined
+   * hosts and microapps is available in the window.
+   * https://developers.google.com/pay/spot/eap/guides/development-setup
+   */
+  hasMediaUploadSupport() {
+    return (
+      this.$window.self !== this.$window.top && (
+        this.microappsHostnames.includes(this.resolveParentHost()) && !!this.$window.microapps
+      )
+    );
+  }
+
+  getParentUrl() {
+    if (
+      this.$document[0].location.ancestorOrigins !== undefined && (
+        this.$document[0].location.ancestorOrigins.length > 0
+      )
+    ) {
+      return this.$document[0].location.ancestorOrigins[0];
+    }
+    return this.$document[0].referrer;
+  }
+
+  resolveParentHost() {
+    const parser = this.$document[0].createElement('a');
+    parser.href = this.getParentUrl();
+    return parser.host;
+  }
+
+  /**
+   * Converts media response to blob.
+   * https://developers.google.com/pay/spot/eap/reference/media-api
+   */
+  // eslint-disable-next-line
+  getBlobFromMedia({ bytes, mimeType }) {
+    const bytesCharacters = atob(bytes);
+    const byteArray = new Array(bytesCharacters.length);
+
+    for (let i = 0; i < bytesCharacters.length; i++) {
+      byteArray[i] = bytesCharacters.charCodeAt(i);
+    }
+
+    const bytesArray = new Uint8Array(byteArray);
+    return new Blob([bytesArray], { type: mimeType });
+  }
+}
+
+MediaApiService.$inject = ['$window', '$document', '$q'];
+
+export default angular
+  .module('tw.styleguide.forms.upload.media-api', [])
+  .service('MediaApiService', MediaApiService)
+  .name;


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
There is a new integration with google where we need to render transferwise.com inside https://microapps.google.com domain. There will be an android native application with a webview which will open transferwise.com inside.

We need to use Media API exposed by microapps for file upload, hence we need to make this the preferred option when the upload component is rendered inside the supported domain.

### Changes

## Changes
<!-- what this PR does -->
Use Media API for file upload when the upload component is rendered inside the supported domain.

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests