### PR TITLE
fix: Fixes twFieldset form validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.1.1
+## Changes twFieldset to use JSON schema style validation
+Previously the two-way bound isValid property was set using angular's ngForm directive. However, this stopped working when we changed the internal validation to avoid using the ngModel pipeline (which was suppressing invalid values from being broadcast).
+
 # v8.1.0
 ## Add Google microapp's Media Api support for file upload
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6797,10 +6797,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7552,12 +7549,6 @@
           }
         }
       }
-    },
-    "icu4c-data": {
-      "version": "0.62.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
-      "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import { getValidModelParts } from '../../json-schema/validation/valid-model';
 import { isUndefined } from '../../json-schema/validation/type-validators';
+import { isValidSchema } from '../../json-schema/validation/schema-validators';
 
 class FieldsetController {
   constructor(TwRequirementsService, $scope, $timeout) {
@@ -32,12 +33,7 @@ class FieldsetController {
 
     this.validationMessages = { ...defaultMessages, ...this.validationMessages };
 
-    this.$scope.$watch('twFieldset.$valid', (validity) => {
-      this.isValid = validity;
-    });
-
     this.submitted = false;
-
     // TODO can we add asyncvalidator here? - prob not
   }
 
@@ -79,11 +75,14 @@ class FieldsetController {
     if (!this.requiredFields || !this.requiredFields.length) {
       this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
     }
+
+    this.validate();
   }
 
   onPropsModelChange(modelChanges) {
     // When the model changes convert array strings to real arrays (for checkbox-group)
     this.internalModel = this.parseArrayStringsInModel(modelChanges.currentValue);
+    this.validate();
   }
 
   /**
@@ -156,6 +155,8 @@ class FieldsetController {
         }
       }
 
+      this.validate();
+
       if (this.onModelChange) {
         this.onModelChange({ model: this.model });
       }
@@ -164,6 +165,15 @@ class FieldsetController {
         this.onRefreshRequirements({ model: this.model });
       }
     });
+  }
+
+  validate() {
+    const schema = {
+      type: 'object',
+      properties: this.fields
+    };
+
+    this.isValid = isValidSchema(this.model, schema);
   }
 
   refreshRequirements() {

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -97,7 +97,7 @@ describe('Fieldset', function() {
     });
   });
 
-  describe('when some fields are required', function() {
+  describe('when some fields are required and values missing', function() {
     var fields;
     beforeEach(function() {
       $scope.fields = getFields();
@@ -113,6 +113,23 @@ describe('Fieldset', function() {
     it('should not pass required to the fields that were not required', function() {
       var ibanField = angular.element(fields[1]);
       expect(ibanField.controller('twField').required).toBe(false);
+    });
+
+    it('should set isValid to false', function() {
+      expect($scope.isValid).toBe(false);
+    });
+
+    describe('when the required field values are added', function() {
+      beforeEach(function() {
+        var sortInput = element.querySelector('input');
+        sortInput.value = "123456";
+        sortInput.dispatchEvent(new Event('input'));
+        $timeout.flush();
+      });
+
+      it('should change isValid to true', function() {
+        expect($scope.isValid).toEqual(true);
+      });
     });
   });
 
@@ -294,6 +311,8 @@ describe('Fieldset', function() {
       expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' });
     });
   });
+
+
 
   function getCompiledDirectiveElement() {
     var template = " \

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -312,8 +312,6 @@ describe('Fieldset', function() {
     });
   });
 
-
-
   function getCompiledDirectiveElement() {
     var template = " \
       <tw-fieldset \


### PR DESCRIPTION
## Context
Previously the two-way bound isValid property was set using angular's ngForm directive. However, this stopped working when we changed the internal validation to avoid using the ngModel pipeline (which was suppressing invalid values from being broadcast).

## Changes
We now use the isValidSchema utility to validate the model as it changes

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests