### PR TITLE
twFieldset now broadcasts an onModelChange with initial model value and validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.1.2
+## twFieldset now sends validity as a second parameter in onModelChange
+Previously validity was communicated by the two-way bound isValid component prop. This was being misused by some consumers to attempt to set internal validity.  We now additionally broadcast validity in the onModelChange callback for a clearer API.
+
 # v8.1.1
 ## Changes twFieldset to use JSON schema style validation
 Previously the two-way bound isValid property was set using angular's ngForm directive. However, this stopped working when we changed the internal validation to avoid using the ngModel pipeline (which was suppressing invalid values from being broadcast).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v8.1.2
+# v8.2.0
 ## twFieldset now sends validity as a second parameter in onModelChange
 Previously validity was communicated by the two-way bound isValid component prop. This was being misused by some consumers to attempt to set internal validity.  We now additionally broadcast validity in the onModelChange callback for a clearer API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.2.1
+## twFieldset now broadcasts an onModelChange with initial model value and validity
+Previously it did not broadcast a change on load, meaning you had to rely on the two-way bound isValid property for initial validation state.  This also fixes a bug where we were not validating required fields.
+
 # v8.2.0
 ## twFieldset now sends validity as a second parameter in onModelChange
 Previously validity was communicated by the two-way bound isValid component prop. This was being misused by some consumers to attempt to set internal validity.  We now additionally broadcast validity in the onModelChange callback for a clearer API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.2",
+  "version": "8.2.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -17,7 +17,6 @@ class FieldsetController {
 
     this.internalModel = this.parseArrayStringsInModel(this.model);
 
-
     if (!this.requiredFields) {
       this.requiredFields = [];
     }
@@ -59,6 +58,12 @@ class FieldsetController {
       this.validationMessages
     );
 
+    if (!this.requiredFields || !this.requiredFields.length) {
+      this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
+    }
+
+    this.validate();
+
     // Remove any model values that are now invalid
     const oldModel = this.internalModel;
     const newModel = getValidModelParts(oldModel, convertFieldsToObject(this.fields));
@@ -67,16 +72,13 @@ class FieldsetController {
     if (!isUndefined(oldModel) && !angular.equals(newModel, oldModel)) {
       this.internalModel = newModel;
       this.model = newModel;
+
+      this.validate(); // Revalidate if the model changed
+
       if (this.onModelChange) {
-        this.onModelChange({ model: newModel });
+        this.onModelChange({ model: newModel, isValid: this.isValid });
       }
     }
-
-    if (!this.requiredFields || !this.requiredFields.length) {
-      this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
-    }
-
-    this.validate();
   }
 
   onPropsModelChange(modelChanges) {
@@ -158,7 +160,7 @@ class FieldsetController {
       this.validate();
 
       if (this.onModelChange) {
-        this.onModelChange({ model: this.model });
+        this.onModelChange({ model: this.model, isValid: this.isValid });
       }
 
       if (field.refreshRequirementsOnChange && this.onRefreshRequirements) {
@@ -173,7 +175,7 @@ class FieldsetController {
       properties: this.fields
     };
 
-    this.isValid = isValidSchema(this.model, schema);
+    this.isValid = isValidSchema(this.internalModel, schema);
   }
 
   refreshRequirements() {

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -24,13 +24,18 @@ describe('Fieldset', function() {
     jest.spyOn($scope, 'onModelChange').mockImplementation(() => {});
   });
 
-  describe('when given an array of fields', function() {
+  describe('when initialised with an array of fields', function() {
     beforeEach(function() {
       $scope.fields = getFields();
       element = getCompiledDirectiveElement();
     });
+
     it('should show the correct number of fields', function() {
       expect(element.querySelectorAll('tw-field').length).toBe(2);
+    });
+
+    it('should trigger an onChange with initial model and validity', function() {
+      expect($scope.onModelChange).toHaveBeenCalledWith({}, true);
     });
   });
 

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -44,16 +44,17 @@ describe('Fieldset', function() {
         items: {
           enum: [1, 2],
           values: [{ value: 1, label: 'One' }, { value: 2, label: 'Two' }]
-        }
+        },
+        minItems: 2
       };
       $scope.fields = { checkboxGroup };
-    });
-
-    it('should render preselected value', () => {
       $scope.model = {
         checkboxGroup: '[2]'
       };
       element = getCompiledDirectiveElement();
+    });
+
+    it('should render preselected value', () => {
       const [option1, option2] = element.querySelectorAll('.checkbox label');
       expect(option1.textContent.trim()).toBe('One');
       expect(option2.textContent.trim()).toBe('Two');
@@ -61,20 +62,49 @@ describe('Fieldset', function() {
       expect(option2.querySelector('button').classList.contains('checked')).toBe(true)
     });
 
-    it('should return string as a model', () => {
-      $scope.model = {
-        checkboxGroup: '[2]'
-      };
-      element = getCompiledDirectiveElement();
-      const button = element.querySelector('.checkbox label button');
-      button.dispatchEvent(new Event('click'));
-      $timeout.flush();
-      expect($scope.model).toEqual({
-        checkboxGroup: '[1,2]'
+    describe('when a checkbox is clicked', () => {
+      beforeEach(() => {
+        const button = element.querySelector('.checkbox label button');
+        button.dispatchEvent(new Event('click'));
+        $timeout.flush();
+      });
+
+      it('should bind the model value as a string', () => {
+        // This is required as V2 only accepts string value submissions
+        // The string will be parsed on the server.
+        expect($scope.model).toEqual({
+          checkboxGroup: '[1,2]'
+        });
+      });
+
+      it('should trigger onModelChange ', () => {
+        expect($scope.onModelChange).toHaveBeenCalledWith({ checkboxGroup: '[1,2]' }, true);
       });
     });
 
-    it('should render legacy data structure properly', () => {
+    describe('when a checkbox is clicked and the control becomes invalid', () => {
+      beforeEach(() => {
+        const button = element.querySelectorAll('.checkbox label button')[1];
+        button.dispatchEvent(new Event('click'));
+        $timeout.flush();
+      });
+
+      it('should bind the model value as a string', () => {
+        // This is required as V2 only accepts string value submissions
+        // The string will be parsed on the server.
+        expect($scope.model).toEqual({
+          checkboxGroup: '[]'
+        });
+      });
+
+      it('should trigger onModelChange ', () => {
+        expect($scope.onModelChange).toHaveBeenCalledWith({ checkboxGroup: '[]' }, false);
+      });
+    });
+  });
+
+  describe('when redndering a legacy style checkbox group', () => {
+    beforeEach(() => {
       $scope.fields = {
         checkboxGroup: {
           title: 'Checkbox Group',
@@ -89,6 +119,9 @@ describe('Fieldset', function() {
         checkboxGroup: '[2]'
       };
       element = getCompiledDirectiveElement();
+    });
+
+    it('should render legacy data structure properly', () => {
       const [option1, option2] = element.querySelectorAll('.checkbox label');
       expect(option1.textContent.trim()).toBe('One');
       expect(option2.textContent.trim()).toBe('Two');

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -110,6 +110,7 @@ describe('Fieldset', function() {
       var sortCodeField = angular.element(fields[0]);
       expect(sortCodeField.controller('twField').required).toBe(true);
     });
+
     it('should not pass required to the fields that were not required', function() {
       var ibanField = angular.element(fields[1]);
       expect(ibanField.controller('twField').required).toBe(false);
@@ -119,16 +120,37 @@ describe('Fieldset', function() {
       expect($scope.isValid).toBe(false);
     });
 
-    describe('when the required field values are added', function() {
+    describe('when the required field values are given valid values', function() {
       beforeEach(function() {
         var sortInput = element.querySelector('input');
-        sortInput.value = "123456";
+        sortInput.value = '123456';
         sortInput.dispatchEvent(new Event('input'));
         $timeout.flush();
       });
 
       it('should change isValid to true', function() {
         expect($scope.isValid).toEqual(true);
+      });
+
+      it('should trigger the change handler with correct validity', function() {
+        expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' }, true);
+      });
+    });
+
+    describe('when the required field values are given invalid values', function() {
+      beforeEach(function() {
+        var sortInput = element.querySelector('input');
+        sortInput.value = '12';
+        sortInput.dispatchEvent(new Event('input'));
+        $timeout.flush();
+      });
+
+      it('should change isValid to true', function() {
+        expect($scope.isValid).toEqual(false);
+      });
+
+      it('should trigger the change handler with correct validity', function() {
+        expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '12' }, false);
       });
     });
   });
@@ -308,7 +330,7 @@ describe('Fieldset', function() {
       expect($scope.model).toEqual({ sortCode: '123456' });
     });
     it('should broadcast a new version of the model with invalid values removed', function() {
-      expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' });
+      expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' }, true);
     });
   });
 
@@ -321,7 +343,7 @@ describe('Fieldset', function() {
         validation-messages='validationMessages' \
         error-messages='errorMessages' \
         warning-messages='warningMessages' \
-        on-model-change='onModelChange(model)' \
+        on-model-change='onModelChange(model, isValid)' \
         on-refresh-requirements='onRefreshRequirements(model)' \
         is-valid='isValid'> \
       </tw-fieldset>";

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,22 +1,20 @@
 function getMockComponent(name) {
   function mockComponentFactory($provide) {
-    (mockComponentFactory.templateText = name + 'content'),
+    mockComponentFactory.templateText = `${name}Content`;
+    mockComponentFactory.name = name;
 
-    (mockComponentFactory.name = name);
-
-    $provide.decorator(name + 'Directive', function($delegate) {
+    $provide.decorator(`${name} Directive`, $delegate => {
       const directive = $delegate[0];
 
       if (directive.templateUrl) {
         delete directive.templateUrl;
       }
 
-      directive.compile = function() {};
+      directive.compile = () => {};
 
-      directive.template =
-        '<div>' + mockComponentFactory.templateText + '</div>';
+      directive.template = `<div>${mockComponentFactory.templateText}</div>`;
 
-      directive.controller = function($attrs) {
+      directive.controller = $attrs => {
         mockComponentFactory.attrs = $attrs;
         mockComponentFactory.bindings = this;
       };


### PR DESCRIPTION
## Context
Previously it did not broadcast a change on load, meaning you had to rely on the two-way bound isValid property for initial validation state.  

## Changes
Broadcasts a change event on load.  This also fixes a bug where we were not validating required fields.

## Considerations
n/a

## Original Pull Request (for version bumps)
n/a

## Screenshots/GIFs
n/a

## Checklist

- [x] All changes are covered by tests