### PR TITLE
Fix string validation when given incorrect minimum/maximum data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.2.2
+## Fix string validation when given incorrect minimum/maximum data type
+When applied to strings, minimum and maximum should also be strings, allowing comparison between iso8601 dates.  A numeric minimum/maximum is invalid and should be ignored.
+
 # v8.2.1
 ## twFieldset now broadcasts an onModelChange with initial model value and validity
 Previously it did not broadcast a change on load, meaning you had to rely on the two-way bound isValid property for initial validation state.  This also fixes a bug where we were not validating required fields.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/json-schema/validation/validation-failures/index.js
+++ b/src/json-schema/validation/validation-failures/index.js
@@ -72,10 +72,10 @@ function getStringValidationFailures(value, schema, isRequired) {
   if (!isValidPattern(value, schema.pattern)) {
     failures.push('pattern');
   }
-  if (!isValidMinimum(value, schema.minimum)) {
+  if (isString(schema.minimum) && !isValidMinimum(value, schema.minimum)) {
     failures.push('minimum');
   }
-  if (!isValidMaximum(value, schema.maximum)) {
+  if (isString(schema.maximum) && !isValidMaximum(value, schema.maximum)) {
     failures.push('maximum');
   }
   return failures;

--- a/src/json-schema/validation/validation-failures/spec.js
+++ b/src/json-schema/validation/validation-failures/spec.js
@@ -68,6 +68,23 @@ describe('Given a library for identifying validation failures', () => {
     });
   });
 
+  describe('when validating a string with an incorrect minimum/maximum', () => {
+    beforeEach(() => {
+      schema = {
+        type: 'string',
+        minimum: 2000,
+        maximum: 2010,
+      };
+    });
+
+    it('should return an empty array for valid strings', () => {
+      expect(getValidationFailures('1999', schema)).toEqual([]);
+      expect(getValidationFailures('2001', schema)).toEqual([]);
+      expect(getValidationFailures('2011', schema)).toEqual([]);
+      expect(getValidationFailures('abc', schema)).toEqual([]);
+    });
+  });
+
   describe('when validating a number schema', () => {
     beforeEach(() => {
       schema = {


### PR DESCRIPTION
## Context
When applied to strings, minimum and maximum should also be strings, allowing comparison between iso8601 dates.  A numeric minimum/maximum is invalid and should be ignored.

## Changes
We now ignore numeric minimum/maximum when validating.

## Considerations
n/a

## Original Pull Request (for version bumps)
n/a

## Checklist

- [x] All changes are covered by tests