### PR TITLE
Throw an error if we’re in the Spot environment but microapps API is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.2.3
+## Throw an error if we’re in the Spot environment but microapps API is not available
+
 # v8.2.2
 ## Fix string validation when given incorrect minimum/maximum data type
 When applied to strings, minimum and maximum should also be strings, allowing comparison between iso8601 dates.  A numeric minimum/maximum is invalid and should be ignored.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.2",
+  "version": "8.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6797,7 +6797,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
       "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7549,6 +7552,12 @@
           }
         }
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.2",
+  "version": "8.2.3",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/upload/capture-card/capture-card.controller.js
+++ b/src/forms/upload/capture-card/capture-card.controller.js
@@ -6,12 +6,7 @@ class Controller {
     this.cameraFailed = false;
     this.MediaApiService = MediaApiService;
     this.checkMediaUploadSupport = this.checkMediaUploadSupport.bind(this);
-
-    if (this.$window.document.readyState === 'complete') {
-      this.checkMediaUploadSupport();
-    } else {
-      this.$window.addEventListener('load', this.checkMediaUploadSupport);
-    }
+    this.checkMediaUploadSupport();
   }
 
   $onChanges(changes) {

--- a/src/forms/upload/capture-card/card-capture.spec.js
+++ b/src/forms/upload/capture-card/card-capture.spec.js
@@ -86,79 +86,81 @@ describe('given a Card Capture component', () => {
   })
 
   describe('when media upload is supported', () => {
-    let deferred;
+    describe('when microapps is in window', () => {
+      let deferred;
 
-    beforeEach(() => {
-      deferred = $q.defer();
+      beforeEach(() => {
+        deferred = $q.defer();
 
-      jest.spyOn(MediaApiService, 'hasMediaUploadSupport').mockReturnValue(true);
-      jest.spyOn(MediaApiService, 'captureFromMedia').mockReturnValue(deferred.promise);
-    })
+        jest.spyOn(MediaApiService, 'hasMediaUploadSupport').mockReturnValue(true);
+        jest.spyOn(MediaApiService, 'captureFromMedia').mockReturnValue(deferred.promise);
+      })
 
-    it('should render a camera button', () => {
-      expect(findCameraButton()).toBeTruthy();
-    })
+      it('should render a camera button', () => {
+        expect(findCameraButton()).toBeTruthy();
+      })
 
-    describe('when isLiveCameraUpload is true', () => {
-      describe('when camera button is clicked', () => {
+      describe('when isLiveCameraUpload is true and camera button is clicked', () => {
         beforeEach(() => {
           $scope.isLiveCameraUpload = true;
-
           compileComponent();
+          findCameraButton().click();
         })
 
-        it('should call captureFromMedia from MediaApiService with true when camera button is clicked', () => {
-          findCameraButton().click();
+        it('should call captureFromMedia from MediaApiService with true', () => {
           expect(MediaApiService.captureFromMedia).toHaveBeenCalledWith(true);
         })
       })
-    })
 
-    describe('when isLiveCameraUpload is false', () => {
-      describe('when camera button is clicked', () => {
+      describe('when isLiveCameraUpload is false and camera button is clicked', () => {
         beforeEach(() => {
           $scope.isLiveCameraUpload = false;
-
           compileComponent();
+          findCameraButton().click();
         })
 
-        it('should call captureFromMedia from MediaApiService with false when camera button is clicked', () => {
-          findCameraButton().click();
+        it('should call captureFromMedia from MediaApiService with false', () => {
           expect(MediaApiService.captureFromMedia).toHaveBeenCalledWith(false);
         })
       })
+
+      describe('when camera button is clicked', () => {
+        beforeEach(() => {
+          $scope.onFileCapture = jest.fn();
+
+          compileComponent();
+          findCameraButton().click();
+        })
+
+        describe('when captureFromMedia is successful', () => {
+          const file = { size: 124, type: 'image/jpeg'};
+
+          beforeEach(() => {
+            deferred.resolve(file);
+            $scope.$apply();
+          })
+
+          it('should call onFileCapture with resolved file', () => {
+            expect($scope.onFileCapture).toHaveBeenCalledWith(file);
+          })
+        })
+
+        describe('when captureFromMedia fails', () => {
+          beforeEach(() => {
+            deferred.reject({error: 'CANCELLED'});
+            $scope.$apply();
+          })
+
+          it('should not call onFileCapture', () => {
+            expect($scope.onFileCapture).not.toHaveBeenCalled();
+          })
+        })
+      })
     })
 
-    describe('when camera button is clicked', () => {
-      beforeEach(() => {
-        $scope.onFileCapture = jest.fn();
-
-        compileComponent();
-        findCameraButton().click();
-      })
-
-      describe('when captureFromMedia is successful', () => {
-        const file = { size: 124, type: 'image/jpeg'};
-
-        beforeEach(() => {
-          deferred.resolve(file);
-          $scope.$apply();
-        })
-
-        it('should call onFileCapture with ressolved file', () => {
-          expect($scope.onFileCapture).toHaveBeenCalledWith(file);
-        })
-      })
-
-      describe('when captureFromMedia fails', () => {
-        beforeEach(() => {
-          deferred.reject({error: 'CANCELLED'});
-          $scope.$apply();
-        })
-
-        it('should not call onFileCapture', () => {
-          expect($scope.onFileCapture).not.toHaveBeenCalled();
-        })
+    describe('when microapps is not in window', () => {
+      it('should throw an error when calling captureFromMedia', () => {
+        expect(() => MediaApiService.captureFromMedia(false)).toThrow('microapps must be available in window to use Spot Platform Media API');
       })
     })
   })

--- a/src/forms/upload/services/media-api.service.js
+++ b/src/forms/upload/services/media-api.service.js
@@ -11,7 +11,7 @@ class MediaApiService {
     this.$window = $window;
     this.$document = $document;
     this.$q = $q;
-    this.microappsHostnames = ['www.microapps.google.com', 'microapps-prod-tt.sandbox.google.com'];
+    this.microappsHostnames = ['microapps.google.com', 'microapps-prod-tt.sandbox.google.com'];
   }
 
   captureFromMedia(isLiveCameraUpload) {
@@ -21,6 +21,10 @@ class MediaApiService {
     };
 
     const deferred = this.$q.defer();
+
+    if (typeof this.$window.microapps === 'undefined') {
+      throw new Error('microapps must be available in window to use Spot Platform Media API');
+    }
 
     this.$window.microapps.requestMedia(request)
       .then((response) => {
@@ -39,7 +43,7 @@ class MediaApiService {
   hasMediaUploadSupport() {
     return (
       this.$window.self !== this.$window.top && (
-        this.microappsHostnames.includes(this.resolveParentHost()) && !!this.$window.microapps
+        this.microappsHostnames.includes(this.resolveParentHost())
       )
     );
   }


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
We previously checked if microapps is in window and if it isn't we fall back to HTML file input or the camera component.
Spot app does not support html file input and does not throw errors when trying using it.
We will always default to use the Media API when within a spot host url which will then throw an error if microapps is not available in window.

## Changes
<!-- what this PR does -->

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests