### PR TITLE
feat: Fieldset will now broadcast an onValidityChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v8.3.0
+## Fieldset now publishes on onValidityChange callback
+This was necessary because changing the fields can change the validity state without changing the model.  Previously we would update validity at the same time as the model changed.
+
 # v8.2.3
 ## Throw an error if we’re in the Spot environment but microapps API is not available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v8.3.0
-## Fieldset now publishes on onValidityChange callback
+## Fieldset now publishes an onValidityChange callback
 This was necessary because changing the fields can change the validity state without changing the model.  Previously we would update validity at the same time as the model changed.
 
 # v8.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.3",
+  "version": "8.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.2.3",
+  "version": "8.3.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/currency-input/currency-input.spec.js
+++ b/src/forms/currency-input/currency-input.spec.js
@@ -164,14 +164,14 @@ describe('CurrencyInput', function() {
       var needle = '';
       templateElement = getCompiledTransclusionTemplateElement($scope, needle);
 
-      expect(templateElement.html()).toContain('<addon></addon>');
+      expect(templateElement.find('addon').text()).toEqual('');
     });
 
     it('should show text, when text provided', function() {
       var needle = 'Addon here?';
       templateElement = getCompiledTransclusionTemplateElement($scope, needle);
 
-      expect(templateElement.html()).toContain('<addon>' + needle + '</addon>');
+      expect(templateElement.find('addon').text()).toEqual(needle);
     });
 
     it('should show compiled component, when component provided', function() {

--- a/src/forms/fieldset/fieldset.component.js
+++ b/src/forms/fieldset/fieldset.component.js
@@ -14,6 +14,7 @@ const Fieldset = {
     title: '@',
     description: '@',
     onModelChange: '&?',
+    onValidityChange: '&?',
     onRefreshRequirements: '&?',
     onFieldFocus: '&?',
     onFieldBlur: '&?',

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -169,7 +169,13 @@ class FieldsetController {
 
   validate() {
     const schema = convertFieldsToObject(this.fields, this.requiredFields);
+
+    const oldIsValid = this.isValid;
     this.isValid = isValidSchema(this.internalModel, schema);
+
+    if (oldIsValid !== this.isValid && this.onValidityChange) {
+      this.onValidityChange({ isValid: this.isValid });
+    }
   }
 
   triggerOnModelChange() {

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -22,6 +22,9 @@ describe('Fieldset', function() {
 
     $scope.onModelChange = function() {};
     jest.spyOn($scope, 'onModelChange').mockImplementation(() => {});
+
+    $scope.onValidityChange = function() {};
+    jest.spyOn($scope, 'onValidityChange').mockImplementation(() => {});
   });
 
   describe('when initialised with an array of fields', function() {
@@ -102,6 +105,10 @@ describe('Fieldset', function() {
         });
       });
 
+      it('should trigger onValidityChange ', () => {
+        expect($scope.onValidityChange).toHaveBeenCalledWith(false);
+      });
+
       it('should trigger onModelChange ', () => {
         expect($scope.onModelChange).toHaveBeenCalledWith({ checkboxGroup: '[]' }, false);
       });
@@ -158,6 +165,10 @@ describe('Fieldset', function() {
       expect($scope.isValid).toBe(false);
     });
 
+    it('should trigger onValidityChange ', () => {
+      expect($scope.onValidityChange).toHaveBeenCalledWith(false);
+    });
+
     describe('when the required field values are given valid values', function() {
       beforeEach(function() {
         var sortInput = element.querySelector('input');
@@ -168,6 +179,10 @@ describe('Fieldset', function() {
 
       it('should change isValid to true', function() {
         expect($scope.isValid).toEqual(true);
+      });
+
+      it('should trigger onValidityChange ', () => {
+        expect($scope.onValidityChange).toHaveBeenCalledWith(true);
       });
 
       it('should trigger the change handler with correct validity', function() {
@@ -185,6 +200,10 @@ describe('Fieldset', function() {
 
       it('should change isValid to true', function() {
         expect($scope.isValid).toEqual(false);
+      });
+
+      it('should trigger onValidityChange ', () => {
+        expect($scope.onValidityChange).toHaveBeenCalledWith(false);
       });
 
       it('should trigger the change handler with correct validity', function() {
@@ -224,6 +243,7 @@ describe('Fieldset', function() {
       $scope.fields = getFields();
       element = getCompiledDirectiveElement();
     });
+
     it('should fallback to default validation messages for remaining messages', function() {
       var fields = element.querySelectorAll('tw-field');
       var sortCodeField = angular.element(fields[0]);
@@ -246,9 +266,11 @@ describe('Fieldset', function() {
       formControl.dispatchEvent(new Event('input'));
       $timeout.flush();
     });
+
     it('should trigger the onRefresh handler', function() {
       expect($scope.onRefreshRequirements).toHaveBeenCalled();
     });
+
     it('should pass the handler the latest model', function() {
       expect($scope.onRefreshRequirements).toHaveBeenCalledWith({ sortCode: 'new' });
     });
@@ -364,9 +386,11 @@ describe('Fieldset', function() {
       $scope.fields = { sortCode: fields.sortCode };
       $scope.$apply();
     })
+
     it('should alter the model to remove invalid values', function() {
       expect($scope.model).toEqual({ sortCode: '123456' });
     });
+    
     it('should broadcast a new version of the model with invalid values removed', function() {
       expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' }, true);
     });
@@ -382,6 +406,7 @@ describe('Fieldset', function() {
         error-messages='errorMessages' \
         warning-messages='warningMessages' \
         on-model-change='onModelChange(model, isValid)' \
+        on-validity-change='onValidityChange(isValid)' \
         on-refresh-requirements='onRefreshRequirements(model)' \
         is-valid='isValid'> \
       </tw-fieldset>";


### PR DESCRIPTION

## Context
We recently changed the focus for validity on broadcasting validity alongside the model as the model changes.  However, in the event that the fields change without changing the model (e.g. a refresh requirements call adds a field), then the new validity was not broadcast.

## Changes
We add an onValidityChange callback that is guaranteed to fire whenever the validity changes.

## Considerations
n/a

## Original Pull Request (for version bumps)
n/a

## Screenshots/GIFs

### Before

n/a

### After

n/a

## Checklist

- [x] All changes are covered by tests