### PR TITLE
breaking: remove requiredFields prop from Fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v9.0.0
+## Removes requiredFields prop from Fieldset
+Required status should come from the fields themselves, not the separate prop. There are no cases in our code base where we depend on this prop, so this should not a breaking change in practice.
+
 # v8.3.1
 ## Disable drag and drop on upload component if it is not eligible
 This change was necessary to block customers to use the drag and drop when they are not supposed to.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.3.1",
+  "version": "9.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "8.3.1",
+  "version": "9.0.0",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/fieldset/fieldset.component.js
+++ b/src/forms/fieldset/fieldset.component.js
@@ -8,7 +8,6 @@ const Fieldset = {
   bindings: {
     model: '=',
     initialFields: '<fields',
-    requiredFields: '<',
     uploadOptions: '<',
     locale: '@',
     title: '@',

--- a/src/forms/fieldset/fieldset.controller.js
+++ b/src/forms/fieldset/fieldset.controller.js
@@ -17,10 +17,6 @@ class FieldsetController {
 
     this.internalModel = this.parseArrayStringsInModel(this.model);
 
-    if (!this.requiredFields) {
-      this.requiredFields = [];
-    }
-
     const defaultMessages = {
       required: 'Required',
       pattern: 'Incorrect format',
@@ -61,9 +57,7 @@ class FieldsetController {
       this.validationMessages
     );
 
-    if (!this.requiredFields || !this.requiredFields.length) {
-      this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
-    }
+    this.requiredFields = this.RequirementsService.getRequiredFields(this.fields);
 
     this.validate();
 

--- a/src/forms/fieldset/fieldset.spec.js
+++ b/src/forms/fieldset/fieldset.spec.js
@@ -146,7 +146,7 @@ describe('Fieldset', function() {
     var fields;
     beforeEach(function() {
       $scope.fields = getFields();
-      $scope.requiredFields = ['sortCode'];
+      $scope.fields.sortCode.required = true;
       element = getCompiledDirectiveElement();
       fields = element.querySelectorAll('tw-field');
     });
@@ -390,7 +390,7 @@ describe('Fieldset', function() {
     it('should alter the model to remove invalid values', function() {
       expect($scope.model).toEqual({ sortCode: '123456' });
     });
-    
+
     it('should broadcast a new version of the model with invalid values removed', function() {
       expect($scope.onModelChange).toHaveBeenCalledWith({ sortCode: '123456' }, true);
     });
@@ -401,7 +401,6 @@ describe('Fieldset', function() {
       <tw-fieldset \
         model='model' \
         fields='fields' \
-        required-fields='requiredFields' \
         validation-messages='validationMessages' \
         error-messages='errorMessages' \
         warning-messages='warningMessages' \


### PR DESCRIPTION

<!-- ☝️ make the title meaningful -->

## Context
Required status should come from the fields themselves, not the separate prop. There are no cases in our code base where we depend on this prop, so this should not a breaking change in practice.

## Changes
Removes the requiredFields prop from Fieldset

## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests