### PR TITLE
fix(Field): handle uppercase field types as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v9.0.1
+## Fix twField control mapping logic
+Handle uppercase-lowercase gracefully when determining `twFormControl` component's `type` binding
+Check description in https://github.com/transferwise/styleguide-components/pull/363
+
 # v9.0.0
 ## Removes requiredFields prop from Fieldset
 Required status should come from the fields themselves, not the separate prop. There are no cases in our code base where we depend on this prop, so this should not a breaking change in practice.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -129,25 +129,19 @@ describe('Field', function() {
     });
   });
 
-  describe('when given type:number', function() {
-    beforeEach(function() {
-      $scope.field = { type: "number" };
+  describe.each([
+    ["number", "number"],
+    ["NUMBER", "number"],
+    ["boolean", "checkbox"],
+    ["BOOLEAN", "checkbox"],
+  ])("when given type:%s", (type, control) => {
+    beforeEach(function () {
+      $scope.field = { type };
       element = getCompiledDirectiveElement();
     });
 
-    it('should ask the form control to render a number input', function() {
-      expect(FormControl.bindings.type).toBe('number');
-    });
-  });
-
-  describe('when given type:boolean', function() {
-    beforeEach(function() {
-      $scope.field = { type: "boolean" };
-      element = getCompiledDirectiveElement();
-    });
-
-    it('should ask the form control to render a telephone input', function() {
-      expect(FormControl.bindings.type).toBe('checkbox');
+    it("should ask the form control to render a number input", function () {
+      expect(FormControl.bindings.type).toBe(control);
     });
   });
 

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -130,17 +130,19 @@ describe('Field', function() {
   });
 
   describe.each([
-    ["number", "number"],
-    ["NUMBER", "number"],
-    ["boolean", "checkbox"],
-    ["BOOLEAN", "checkbox"],
+    ['number', 'number'],
+    ['NUMBER', 'number'],
+    ['integer', 'number'],
+    ['INTEGER', 'number']
+    ['boolean', 'checkbox'],
+    ['BOOLEAN', 'checkbox'],
   ])("when given type:%s", (type, control) => {
     beforeEach(function () {
       $scope.field = { type };
       element = getCompiledDirectiveElement();
     });
 
-    it("should ask the form control to render a number input", function () {
+    it('should ask the form control to render a number input', function () {
       expect(FormControl.bindings.type).toBe(control);
     });
   });

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -142,7 +142,7 @@ describe('Field', function() {
       element = getCompiledDirectiveElement();
     });
 
-    it('should ask the form control to render a number input', function () {
+    it(`should ask the form control to render a ${control} input`, function () {
       expect(FormControl.bindings.type).toBe(control);
     });
   });

--- a/src/forms/field/field.spec.js
+++ b/src/forms/field/field.spec.js
@@ -133,7 +133,7 @@ describe('Field', function() {
     ['number', 'number'],
     ['NUMBER', 'number'],
     ['integer', 'number'],
-    ['INTEGER', 'number']
+    ['INTEGER', 'number'],
     ['boolean', 'checkbox'],
     ['BOOLEAN', 'checkbox'],
   ])("when given type:%s", (type, control) => {

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -176,7 +176,7 @@ function RequirementsService($http) {
   }
 
   this.prepType = (field) => {
-    const type = getFieldType(field);
+    const type = safeToLowerCase(field.type);
 
     switch (type) {
       case 'text':
@@ -493,11 +493,8 @@ function getRequiredFields(fields) {
   return Object.keys(fields).filter(property => fields[property].required);
 }
 
-function getFieldType(field) {
-  if (typeof field.type === 'string') {
-    return field.type.toLowerCase();
-  }
-  return field.type;
+function safeToLowerCase(value) {
+  return typeof value === 'string' ? value.toLowerCase() : value;
 }
 
 function getControlType(field) {
@@ -518,9 +515,9 @@ function getControlType(field) {
     return getSelectionType(field);
   }
 
-  const fieldType = getFieldType(field);
+  const type = safeToLowerCase(field.type);
 
-  switch (fieldType) {
+  switch (type) {
     case 'string':
       return getControlForStringFormat(field.format);
     case 'number':
@@ -534,7 +531,7 @@ function getControlType(field) {
 }
 
 function getControlForStringFormat(format) {
-  switch (format) {
+  switch (safeToLowerCase(format)) {
     case 'date':
       return 'date';
     case 'base64url':

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -176,7 +176,7 @@ function RequirementsService($http) {
   }
 
   this.prepType = (field) => {
-    const type = field.type && field.type.toLowerCase && field.type.toLowerCase();
+    const type = getFieldType(field);
 
     switch (type) {
       case 'text':
@@ -493,6 +493,13 @@ function getRequiredFields(fields) {
   return Object.keys(fields).filter(property => fields[property].required);
 }
 
+function getFieldType(field) {
+  if (typeof field.type === 'string') {
+    return field.type.toLowerCase();
+  }
+  return field.type;
+}
+
 function getControlType(field) {
   if (field.control) {
     if (field.control === 'select' && field.selectType === 'CHECKBOX') {
@@ -511,7 +518,9 @@ function getControlType(field) {
     return getSelectionType(field);
   }
 
-  switch (field.type) {
+  const fieldType = getFieldType(field);
+
+  switch (fieldType) {
     case 'string':
       return getControlForStringFormat(field.format);
     case 'number':


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
`twField` component incorrectly mapped upper case field type names (`number` vs `NUMBER`) and this resulted in fields having `text` control type - while they should have been something different.

This caused validation issues. Let's take for example field type `NUMBER` - this is the value that's being returned by Dynamic Flows V2 (DF V2) field type value on the network. Example network response for such field:
```
            {
              '@class': 'ee.tw.dynamic.interfaces.structure.field.NumberField',
              key: 'transferId',
              name: 'Transfer number',
              description: null,
              width: 'lg',
              type: 'NUMBER',
              required: true,
              hidden: false,
              placeholder: '12345678',
              helpText: null,
              columns: null,
              validationRegexp: '\\d+',
              validationMessages: null,
              refreshRequirementsOnChange: false,
              min: 0,
              max: 2147483647,
              example: null,
            },
```

In the client side code data flows from `twField` to `twFormControl`, something like this:

```html
<tw-field>
  <tw-form-control type="{{ $ctrl.control | lowercase }}" />
</tw-field>
```

When field data arrives to `twField`, the component transforms the `field` object according to legacy rules - this is done in `RequirementsService.prepField`. This method converts the `field.type` value to a lowercase string. 

At line 14 `this.field.type` would be `"number"`.  So far so good.

https://github.com/transferwise/styleguide-components/blob/d62284fcfcd5a33d63d02b1b0ca3c22642e59967/src/forms/field/field.controller.js#L11-L16

However at line 15 we pass down the original `field` POJO - not the one that we've just transformed. So in this case `field.type` is `"NUMBER"`.

The value returned by `RequirementsService.getControlType` is being passed down to the `twFormControl` component. If you check the current diff, you can see that this method expects that `field.type` is a lowercase string. Remember, we call `getControlType` with the original `field` object and not the one where we already transformed the `field.type` value to lowercase.

So at the end when this function gets called with `field.type` having a value of `"NUMBER"` for example, according to the current implementation this function returns `text` as a fallback in the switch-case. This is problematic.

In this particular `"NUMBER"` example this behaviour breaks the validation of the `field` and the component won't emit a "valid model" event. Due to this the `twFieldset` component remains "invalid", thus the `twForm` is not valid so the current DF alternative form is not submittable so customers get stuck submitting this step.

## Changes
<!-- what this PR does -->
This PR makes sure that `RequirementsService.getControlType` transforms `field.type` to a lowercase string just like `RequirementsService.prepField` does.

## Considerations
<!-- additional info for reviewing, discussion topics -->
We might change the argument of `RequirementsService.getControlType` at line 15 to `this.field` - I am just not sure whether that would have any side-effects.

https://github.com/transferwise/styleguide-components/blob/d62284fcfcd5a33d63d02b1b0ca3c22642e59967/src/forms/field/field.controller.js#L11-L16


## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [ ] All changes are covered by tests