### PR TITLE
fix(json-schema): handle case sensitive schema types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v9.0.2
+## Fix schema type case sensitivity bug
+Bug fixed where validation failed if schema type is uppercase instead of the expected lowercase (e.g.: `NUMBER` instead of `number`)
+
+
 # v9.0.1
 ## Fix twField control mapping logic
 Handle uppercase-lowercase gracefully when determining `twFormControl` component's `type` binding

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/styleguide-components",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "TransfeWise AngularJS 1.x Styleguide Components",
   "license": "MIT",
   "scripts": {

--- a/src/json-schema/array-schema/controller.js
+++ b/src/json-schema/array-schema/controller.js
@@ -1,3 +1,5 @@
+import { safeToLowerCase } from '../../utils';
+
 const simpleTypes = ['string', 'number', 'integer', 'boolean'];
 
 class Controller {
@@ -36,7 +38,7 @@ class Controller {
   }
 
   isSimpleType(type) { // eslint-disable-line
-    return simpleTypes.indexOf(type) >= 0;
+    return simpleTypes.indexOf(safeToLowerCase(type)) >= 0;
   }
 }
 

--- a/src/json-schema/validation/schema-validators/index.js
+++ b/src/json-schema/validation/schema-validators/index.js
@@ -1,3 +1,4 @@
+import { safeToLowerCase } from '../../../utils';
 import { isObject, isArray } from '../type-validators';
 
 import {
@@ -100,7 +101,9 @@ function isValidSchema(value, schema) {
     return isValidConstSchema(value, schema);
   }
 
-  switch (schema.type) {
+  const type = safeToLowerCase(schema.type);
+
+  switch (type) {
     case 'string':
       return isValidStringSchema(value, schema);
     case 'number':

--- a/src/json-schema/validation/schema-validators/spec.js
+++ b/src/json-schema/validation/schema-validators/spec.js
@@ -141,4 +141,21 @@ describe('Given a library for validating json schema models', () => {
       expect(isValidSchema({ a: 'bc', b: 2 }, schema)).toBe(true);
     });
   });
+
+  describe.each([
+    ['string', 'example string'],
+    ['number', 123456.987654],
+    ['integer', 123456],
+    ['boolean', true],
+    ['array', []],
+    ['object', {}],
+  ])('when validating a %s schema with correct value', (type, value) => {
+    it.each([[type], [type.toUpperCase()]])(
+      'should return true for %s',
+      (exactType) => {
+        const schema = { type: exactType };
+        expect(isValidSchema(value, schema));
+      }
+    );
+  });
 });

--- a/src/json-schema/validation/valid-model/index.js
+++ b/src/json-schema/validation/valid-model/index.js
@@ -1,3 +1,4 @@
+import { safeToLowerCase } from '../../../utils';
 import {
   isString,
   isNumber,
@@ -26,8 +27,10 @@ function getValidModelParts(model, schema) {
     return model;
   }
 
-  if (schema.type) {
-    switch (schema.type) {
+  const type = safeToLowerCase(schema.type);
+
+  if (type) {
+    switch (type) {
       case 'object':
         return cleanModelWithObjectSchema(model, schema);
       case 'array':

--- a/src/json-schema/validation/validation-failures/index.js
+++ b/src/json-schema/validation/validation-failures/index.js
@@ -18,6 +18,7 @@ import {
   isValidMinItems,
   isValidMaxItems
 } from '../rule-validators';
+import { safeToLowerCase } from '../../../utils';
 
 function getValidationFailures(value, schema, isRequired) {
   if (isNull(value)) {
@@ -32,7 +33,9 @@ function getValidationFailures(value, schema, isRequired) {
     return getConstValidationFailures(value, schema, isRequired);
   }
 
-  switch (schema.type) {
+  const type = safeToLowerCase(schema.type);
+
+  switch (type) {
     case 'string':
       return getStringValidationFailures(value, schema, isRequired);
     case 'number':

--- a/src/services/requirements/requirements.service.js
+++ b/src/services/requirements/requirements.service.js
@@ -1,3 +1,5 @@
+import { safeToLowerCase } from '../../utils';
+
 function RequirementsService($http) {
   this.prepRequirements = (alternatives) => {
     if (!alternatives || !alternatives.length) {
@@ -491,10 +493,6 @@ function getRequiredFields(fields) {
   }
   // Return array of keys that have required set
   return Object.keys(fields).filter(property => fields[property].required);
-}
-
-function safeToLowerCase(value) {
-  return typeof value === 'string' ? value.toLowerCase() : value;
 }
 
 function getControlType(field) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export * from './string-utils';

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -1,5 +1,11 @@
 /* eslint-disable import/prefer-default-export */
 
+
+/**
+ * Safely returns the lowercased value of a string
+ * @param {string} value
+ * @returns {string}
+ */
 export function safeToLowerCase(value) {
   return typeof value === 'string' ? value.toLowerCase() : value;
 }

--- a/src/utils/string-utils.js
+++ b/src/utils/string-utils.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
+export function safeToLowerCase(value) {
+  return typeof value === 'string' ? value.toLowerCase() : value;
+}


### PR DESCRIPTION
<!-- ☝️ make the title meaningful -->

## Context
<!-- why this change is made -->
For context, please check #363 
That PR fixed one bug, but it was not fixed all issues with case sensitive field types - this PR fixes all of these issues.
## Changes
<!-- what this PR does -->
- use `safeToLowerCase` wherever we expect lowercase schema type values
- add test for `isValidSchema` with lowercase and uppercase schema types as well
## Considerations
<!-- additional info for reviewing, discussion topics -->

## Original Pull Request (for version bumps)
<!-- if you're bumping a package like `pay-in`, include a link to the PR in the other repository/any other important version bumps down the chain -->

## Screenshots/GIFs
<!-- required for all visual changes -->

### Before

<!-- screenshot before change -->

### After

<!-- screenshot after change -->

## Checklist

- [x] All changes are covered by tests